### PR TITLE
docker: Reduce development envirment build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ docker-compose up
 
 ## Development
 
+### Already up application with `docker-compose up` ?
+
+Attach to current web container with `docker-compose exec web bash`
+and then use all commands listed below without `docker-compose run web ..`
+for example:
+run:  
+
+```bash
+docker-compose exec web bash
+```
+
+And then insite web container just run any command that you need as usual:  
+
+```bash
+rails c
+```
+
 ### Running rails console
 
 ```bash
@@ -52,8 +69,7 @@ bundle exec rspec
 Update `Gemfile` and run
 
 ```bash
-bundle install
-docker-compose build
+docker-compose run web bundle install
 ```
 
 You will need to restart the server if running:
@@ -66,7 +82,7 @@ docker-compose restart
 
 ```bash
 bundle update spree
-docker-compose build
+docker-compose build web
 ```
 
 ## Environment variables

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,5 @@
 
 rm -rf .env && cp -f .env.sample .env &&
-docker-compose pull &&
 docker-compose build web &&
 docker-compose run --rm web bash -c '
   bin/wait-for-services &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - 'redis:/data'
   web:
+    image: spree_starter
     depends_on:
       - 'postgres'
       - 'redis'
@@ -31,9 +32,7 @@ services:
       WEBPACKER_DEV_SERVER_HOST: webpacker
       DISABLE_SPRING: 1
   webpacker:
-    build:
-      context: .
-      dockerfile: Dockerfile.development
+    image: spree_starter
     environment:
       - NODE_ENV=development
       - RAILS_ENV=development
@@ -44,12 +43,10 @@ services:
     ports:
       - '3035:3035'
   worker:
+    image: spree_starter
     depends_on:
       - 'postgres'
       - 'redis'
-    build:
-      context: .
-      dockerfile: Dockerfile.development
     command: bundle exec sidekiq -C config/sidekiq.yml
     volumes:
       - 'bundle_cache:/bundle'


### PR DESCRIPTION
## Description

Improve speed of build local docker environment
Using one spree_starter shared docker image for all services (sidekiq worker, webpacker, web)
The current version of docker-compose.yml builds an independents image for each service that we need to run the rails app

- Reduce time of build/rebuild docker development environment 

Also, I think needs an updated Readme because no need to rebuild the image after each update Gemfile/Gemfile.lock
We have all Gems cached at docker volume bundle_cache
