### PR TITLE
Take the 'web' service's host port from DOCKER_HOST_WEB_PORT env and default to 3000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       dockerfile: Dockerfile.development
     command: bash -c "rm -rf tmp/pids/server.pid && bundle exec rails s -b 0.0.0.0 -p 3000"
     ports:
-      - "3000:3000"
+      - '${DOCKER_HOST_WEB_PORT:-3000}:3000'
     volumes:
       - 'bundle_cache:/bundle'
       - '.:/app'


### PR DESCRIPTION
## Description

Using variable substitution in the `docker-compose.yml` for the `web` service's port value makes it settable in the `.env` file and removes the need to modify `docker-compose.yml`. The default host port is still `3000` if `DOCKER_HOST_WEB_PORT ` is not provided or empty.

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
