### PR TITLE
Change default port from 3000 to 4000

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -28,6 +28,6 @@ ENV PATH="${BUNDLE_BIN}:${PATH}"
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
-EXPOSE 3000
+EXPOSE 4000
 
 CMD ["bash"]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -39,5 +39,5 @@ RUN SECRET_KEY_BASE=skb DB_ADAPTER=nulldb bundle exec rails assets:precompile
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
 
-EXPOSE 3000
+EXPOSE 4000
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This a dockerized [Spree Commerce](https://spreecommerce.org) application templa
 bin/setup
 ```
 
-This will automatically launch the application at `http://localhost:3000`
+This will automatically launch the application at `http://localhost:4000`
 
 #### (Optional) Import sample data such as products, categories, etc
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  config.action_mailer.default_url_options = { host: 'http://localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'http://localhost:4000' }
 
   config.cache_classes = true
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,9 +8,9 @@ max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+# Specifies the `port` that Puma will listen on to receive requests; default is 4000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 4000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.development
-    command: bash -c "rm -rf tmp/pids/server.pid && bundle exec rails s -b 0.0.0.0 -p 3000"
+    command: bash -c "rm -rf tmp/pids/server.pid && bundle exec rails s -b 0.0.0.0 -p 4000"
     ports:
-      - '${DOCKER_HOST_WEB_PORT:-3000}:3000'
+      - '${DOCKER_HOST_WEB_PORT:-4000}:4000'
     volumes:
       - 'bundle_cache:/bundle'
       - '.:/app'


### PR DESCRIPTION
## Description

Many services integrating with Spree already use port `3000` by default. Changing Spree Starter's port to `4000` will make setting up Spree along with those services easier locally.

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
