### PR TITLE
Fix one click deploys to Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,3 +16,7 @@ services:
           property: connectionString
       - key: SECRET_KEY_BASE
         generateValue: true
+      - key: ADMIN_EMAIL
+        value: 'spree@example.com'
+      - key: ADMIN_PASSWORD
+        value: 'spree123'


### PR DESCRIPTION
Deploys to Render via the 'Deploy to Render' button are failing with the following prompt:

```
Nov 29 02:03:39 PM  Create the admin user (press enter for defaults).
Nov 29 02:03:39 PM  rails aborted!
Nov 29 02:03:39 PM  EOFError: The input stream is exhausted.
```

when the migration/seeds are been executed.

This PR matches `render.yaml` to be more like the Heroku `app.json` and specifies the admin user/password as environment variables which allows the deploy to successfully complete.