### PR TITLE
Lock Heroku stack to `heroku-20` in `app.json`

### DIFF
--- a/app.json
+++ b/app.json
@@ -43,5 +43,6 @@
     {
       "url": "heroku/ruby"
     }
-  ]
+  ],
+  "stack": "heroku-20"
 }


### PR DESCRIPTION
## Description

The default new stack is `heroku-22` which does not support Ruby 3.0.x.

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
