### PR TITLE
set vips as default image processing gem

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,1 +1,2 @@
 Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
+Rails.application.config.active_storage.variant_processor = :vips


### PR DESCRIPTION
Move the default configuration setting for processing_variant from spree/spree to spree_starter to allow users to choose whether they want to use VIPS or mini_magick. Default image processing remains as VIPS.

See accompanying change in spree/spree: https://github.com/spree/spree/pull/11792