### PR TITLE
legacy frontend troubleshooting note

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ docker-compose up
 
 * [Docker](https://www.docker.com/community-edition#/download)
 * Ruby 3.0.3
+* [libvips](https://www.libvips.org/install.html)
 
 #### Run setup script
 
@@ -66,10 +67,10 @@ docker-compose run web rake spree_sample:load
 #### Install required tools and dependencies
 
 1. HomeBrew - https://brew.sh/
-2. Install required packages
+2. Install required packages: GPG, PostgreSQL, Redis, ImageMagick, and VIPS
 
       ```bash
-      brew install gpg postgresql redis imagemagick
+      brew install gpg postgresql redis imagemagick vips
       createuser -P -d postgres
       ```
 
@@ -147,6 +148,17 @@ docker-compose restart
 | DB_POOL | database connection pool | 5 |
 | MEMCACHED_POOL_SIZE | memcache connection pool | 5 |
 | SENDGRID_API_KEY | API key to interface Sendgrid API | |
+
+## Troubleshooting
+
+### libvips error
+
+If you are building the application using the latest code, you may encounter the following libvips error:
+```
+LoadError: Could not open library 'vips.so.42'
+```
+This error is usually an indication that you do not have libvips installed locally on your machine. Check that libvips is installed with `vips -v`, and if it is not installed, follow [installation instructions here](https://www.libvips.org/install.html).
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -163,16 +163,7 @@ This error is usually an indication that you do not have libvips installed local
 
 This issue is specific to running with [spree_legacy_frontend](https://github.com/spree/spree_legacy_frontend).
 
-If you notice that the 'Add to Cart' button is disabled on product pages, try the following:
-* run `yarn build` again in your main repo
-* if that doesn't fix the issue, try running the following setup commands again:
-  ```
-  bin/rails javascript:install:esbuild
-  bin/rails turbo:install
-  bin/rails g spree:frontend:install
-  ```
-
-This issue may come up if you switch the source of your `spree_frontend` in your Gemfile, e.g. from github to a local path, etc.
+If you notice that the 'Add to Cart' button is disabled on product pages, try the troubleshooting instructions found in the spree_legacy_frontend ReadMe. <-ADD LINK HERE!
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ LoadError: Could not open library 'vips.so.42'
 ```
 This error is usually an indication that you do not have libvips installed locally on your machine. Check that libvips is installed with `vips -v`, and if it is not installed, follow [installation instructions here](https://www.libvips.org/install.html).
 
+### disabled 'Add to Cart' button
+
+This issue is specific to running with [spree_legacy_frontend](https://github.com/spree/spree_legacy_frontend).
+
+If you notice that the 'Add to Cart' button is disabled on product pages, try the following:
+* run `yarn build` again in your main repo
+* if that doesn't fix the issue, try running the following setup commands again:
+  ```
+  bin/rails javascript:install:esbuild
+  bin/rails turbo:install
+  bin/rails g spree:frontend:install
+  ```
+
+This issue may come up if you switch the source of your `spree_frontend` in your Gemfile, e.g. from github to a local path, etc.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This error is usually an indication that you do not have libvips installed local
 
 This issue is specific to running with [spree_legacy_frontend](https://github.com/spree/spree_legacy_frontend).
 
-If you notice that the 'Add to Cart' button is disabled on product pages, try the troubleshooting instructions found in the spree_legacy_frontend ReadMe. <-ADD LINK HERE!
+If you notice that the 'Add to Cart' button is disabled on product pages, try the [troubleshooting instructions](https://github.com/spree/spree_legacy_frontend#disabled-add-to-cart-button-issue) found in the spree_legacy_frontend ReadMe.
 
 
 ## License


### PR DESCRIPTION
Add a note on the disabled "add to cart" button issue with the spree legacy frontend.

Link to the troubleshooting instructions in legacy frontend repo.
