### PR TITLE
Add deploy instructions for using legacy frontend 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,38 @@ This a dockerized [Spree Commerce](https://spreecommerce.org) application templa
 
 ## Deploy in the cloud
 
+### Using Heroku
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
+### Using Render
 <a href="https://render.com/deploy?repo=https://github.com/spree/spree_starter/tree/main">
   <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render" height=32>
 </a>
+
+Note that sample data does not automatically get loaded when deploying to Render with the default configuration. In order to add sample data, run the following commands in the web service shell:
+```shell
+bundle exec rails db:seed
+bundle exec rake spree_sample:load
+```
+
+#### Deploying to Render with Spree Legacy Frontend
+To deploy to render with the Spree Legacy Frontend, first follow the instructions in the [legacy frontend ReadMe](https://github.com/spree/spree_legacy_frontend#installation) on adding the appropriate gems to your gemfile, and update the web service build command to use `bin/render-build-legacy-frontend.sh`, like so:
+```yaml
+services:
+  - type: web
+    name: spree
+    env: ruby
+    buildCommand: "./bin/render-build-legacy-frontend.sh"
+```
+
+After that, you'll be ready to deploy to render.
 
 ## Local Installation
 
 ### Using Docker (Recommended)
 #### Install required tools and dependencies:
 
-  * [Docker](https://www.docker.com/community-edition#/download)
+* [Docker](https://www.docker.com/community-edition#/download)
 
 #### Run setup script
 

--- a/bin/render-build-legacy-frontend.sh
+++ b/bin/render-build-legacy-frontend.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rails assets:clean
+bundle exec rails db:migrate
+
+# Setup commands specific to legacy frontend
+yes | bundle exec rails javascript:install:esbuild
+yes | bundle exec rails turbo:install
+yes | bundle exec rails g spree:frontend:install
+yarn build
+
+# asset precompile must be run after installing turbo, etc.
+bundle exec rails assets:precompile

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Note: any build commands added/changed in this script should also be update to render-build-legacy-frontend.sh
+
 # exit on error
 set -o errexit
 


### PR DESCRIPTION
Deploy instructions for using legacy frontend with Render, and additional build script file to be used for this case.