### PR TITLE
Add redis to render config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GIT
 
 GIT
   remote: https://github.com/spree/spree_auth_devise.git
-  revision: 60032d83b66aabfb594c7bf2c21e0eeffcc834cd
+  revision: 0de310f918728960a89880679694a4a1162115ec
   branch: main
   specs:
     spree_auth_devise (4.4.2)
@@ -626,7 +626,7 @@ GEM
       spree_core
       timecop
       webdrivers (~> 4.3)
-    spree_extension (0.0.9)
+    spree_extension (0.1.0)
       activerecord (>= 4.2)
       spree_core
     spring (4.1.0)

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,7 @@ services:
       - key: REDIS_URL
         fromService:
           type: redis
-          name: spree_legacy_redis
+          name: spree_redis
           property: connectionString
       - key: SECRET_KEY_BASE
         generateValue: true
@@ -26,5 +26,5 @@ services:
       - key: ADMIN_PASSWORD
         value: 'spree123'
   - type: redis
-    name: spree_legacy_redis
+    name: spree_redis
     ipAllowList: [] # only allow internal connections

--- a/render.yaml
+++ b/render.yaml
@@ -14,9 +14,17 @@ services:
         fromDatabase:
           name: spree
           property: connectionString
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: spree_legacy_redis
+          property: connectionString
       - key: SECRET_KEY_BASE
         generateValue: true
       - key: ADMIN_EMAIL
         value: 'spree@example.com'
       - key: ADMIN_PASSWORD
         value: 'spree123'
+  - type: redis
+    name: spree_legacy_redis
+    ipAllowList: [] # only allow internal connections


### PR DESCRIPTION
Add Redis to render config. This update has been tested on the `spree-4-5-development-legacy-frontend` branch, and the render config is applied to the current deployment of the [Spree 4.5 Legacy Frontend staging environment](https://spree-staging-4-5.upsidelab.net/). 

`spree_auth_config` gem has also been updated to latest version.