### PR TITLE
Update spree config initialization to be compatible w rails 7

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -9,10 +9,12 @@
 #
 # In order to initialize a setting do:
 # config.setting_name = 'new value'
-Spree.config do |config|
-  # Example:
-  # Uncomment to stop tracking inventory levels in the application
-  # config.track_inventory_levels = false
+Rails.application.config.after_initialize do
+  Spree.config do |config|
+    # Example:
+    # Uncomment to stop tracking inventory levels in the application
+    # config.track_inventory_levels = false
+  end
 end
 
 Spree.user_class = 'Spree::User'


### PR DESCRIPTION
For Rails 7 compatibility, spree config must be initialized after rails config initialization completes. This change should be merged to main and not to spree-4-6-development, since it relates to 4.5 updates.