### PR TITLE
Remove loading seeds and samples from render build script

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -8,5 +8,3 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
-bundle exec rails db:seed
-bundle exec rake spree_sample:load


### PR DESCRIPTION
## Description

The `bin/render-build.sh` gets executed every time Render redeploys a web service (e.g. after changing instance size). The seeds will fail to load if they're loaded once than more. 

Since the README for Render deployment already covers the step to load seeds manually, I think we should remove it from the script. 

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
