### PR TITLE
Remove migration from Spree 4.6 beta

### DIFF
--- a/db/migrate/20221221100702_add_selected_locale_to_spree_users.spree.rb
+++ b/db/migrate/20221221100702_add_selected_locale_to_spree_users.spree.rb
@@ -1,9 +1,0 @@
-# This migration comes from spree (originally 20221215151408)
-class AddSelectedLocaleToSpreeUsers < ActiveRecord::Migration[6.1]
-  def change
-    if Spree.user_class.present?
-      users_table_name = Spree.user_class.table_name
-      add_column users_table_name, :selected_locale, :string unless column_exists?(users_table_name, :selected_locale)
-    end
-  end
-end


### PR DESCRIPTION
## Description

At some point we accidentally added a migration from 4.6 to the main branch in this repository. Since main works on Spree 4.5, it shouldn't be here.

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
