### PR TITLE
Add DST to COPY command

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -20,7 +20,7 @@ RUN apt-get clean -qy \
 RUN mkdir /app
 WORKDIR /app
 
-COPY package.json yarn.lock
+COPY package.json yarn.lock .
 RUN yarn install
 
 # install specific version of bundler

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -20,7 +20,7 @@ RUN apt-get clean -qy \
 RUN mkdir /app
 WORKDIR /app
 
-COPY package.json yarn.lock
+COPY package.json yarn.lock .
 RUN yarn install
 
 # install specific version of bundler


### PR DESCRIPTION
## Description

From [docker docs](https://docs.docker.com/engine/reference/builder/#copy) the `COPY` command is `COPY <src> <dst>` so `package.json` was being copied as `yarn.lock`. This is causing some errors when building the docker image.

