### PR TITLE
Updated Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.2.2'
+ruby '~> 3.2.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 7.1.0'


### PR DESCRIPTION
## Description

Changed Ruby version from rigid "3.2.2" to a partial match "~> 3.2.0", so that other Ruby versions 3.2.* will work too.

