### PR TITLE
Zeitwerk conditionally ignore payments_controller.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,14 @@ module SpreeStarter
       require "#{Rails.root}/lib/cloud_flare_middleware"
       config.middleware.insert_before(0, Rack::CloudFlareMiddleware)
     end
+
+    # ignoring files by Zeitwerk when spree_frontend isn't loaded
+    unless ::Spree::Core::Engine.frontend_available?
+      Dir.chdir(Rails.root.join(".."))
+      files_to_ignore = Dir["**/spree_stripe/payments_controller.rb"]
+      files_to_ignore.each { |file| 
+        Rails.autoloaders.main.ignore(Rails.root.join("../#{file}"))
+      }
+    end
   end
 end


### PR DESCRIPTION
When loading spree_stripe without loading spree_frontend (which is optional and doesn't have to be included) there is Zeitwerk error. The error stems from the fact that the file `spree_stripe/app/controllers/spree/spree_stripe/payments_controller.rb` doesn't define a PaymentsController class when spree_frontend isn't loaded. The solution is to conditionally ignore said file while running autoloader.

