### PR TITLE
Do not require `REDIS_CACHE_URL` env variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,14 +69,16 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   # https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore
-  cache_servers = ENV.fetch('REDIS_CACHE_URL', 'redis://localhost:6380/0,redis://localhost:6381/0').split(',')
-  config.cache_store = :redis_cache_store, {
-    url: cache_servers,
-    connect_timeout:    30,  # Defaults to 1 second
-    read_timeout:       0.2, # Defaults to 1 second
-    write_timeout:      0.2, # Defaults to 1 second
-    reconnect_attempts: 2,   # Defaults to 1
-  }
+  if ENV['REDIS_CACHE_URL'].present?
+    cache_servers = ENV['REDIS_CACHE_URL'].split(',') # if multiple instances are provided
+    config.cache_store = :redis_cache_store, {
+      url: cache_servers,
+      connect_timeout:    30,  # Defaults to 1 second
+      read_timeout:       0.2, # Defaults to 1 second
+      write_timeout:      0.2, # Defaults to 1 second
+      reconnect_attempts: 2,   # Defaults to 1
+    }
+  end
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the production caching behavior so that caching settings are only applied when explicitly configured via an environment variable. This update streamlines the production setup and helps ensure more stable and predictable caching performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->