### PR TITLE
Add standalone devise authentication controllers for storefront

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
           POSTGRES_PASSWORD: password
     environment:
       RAILS_ENV: test
+      SECRET_KEY_BASE: dummy
+      MAIL_FROM_ADDRESS: support@mystore.com
       CIRCLE_TEST_REPORTS: /tmp/test-results
       CIRCLE_ARTIFACTS: /tmp/test-artifacts
     working_directory: ~/app

--- a/app/controllers/spree/user_passwords_controller.rb
+++ b/app/controllers/spree/user_passwords_controller.rb
@@ -1,0 +1,33 @@
+module Spree
+  class UserPasswordsController < ::Devise::PasswordsController
+    helper_method :title, :password_path
+    layout 'spree/storefront'
+
+    include Spree::Core::ControllerHelpers::Order
+    include Spree::LocaleUrls
+    include Spree::ThemeConcern
+    include Spree::IntegrationsHelper if defined?(Spree::IntegrationsHelper)
+
+    helper 'spree/wishlist'
+    helper 'spree/currency'
+    helper 'spree/locale'
+    helper 'spree/storefront_locale'
+    helper 'spree/integrations' if defined?(Spree::IntegrationsHelper)
+
+    protected
+
+    def translation_scope
+      'devise.user_passwords'
+    end
+
+    private
+
+    def password_path(_resource_or_scope = nil)
+      send("#{Spree.user_class.model_name.singular_route_key}_password_path")
+    end
+
+    def title
+      Spree.t(:forgot_password)
+    end
+  end
+end

--- a/app/controllers/spree/user_registrations_controller.rb
+++ b/app/controllers/spree/user_registrations_controller.rb
@@ -1,0 +1,30 @@
+module Spree
+  class UserRegistrationsController < ::Devise::RegistrationsController
+    helper_method :title
+    layout 'spree/storefront'
+
+    include Spree::Core::ControllerHelpers::Order
+    include Spree::LocaleUrls
+    include Spree::ThemeConcern
+    include Spree::AnalyticsHelper
+    include Spree::IntegrationsHelper if defined?(Spree::IntegrationsHelper)
+
+    helper 'spree/wishlist'
+    helper 'spree/currency'
+    helper 'spree/locale'
+    helper 'spree/storefront_locale'
+    helper 'spree/integrations' if defined?(Spree::IntegrationsHelper)
+
+    protected
+
+    def translation_scope
+      'devise.user_registrations'
+    end
+
+    private
+
+    def title
+      Spree.t(:sign_up)
+    end
+  end
+end

--- a/app/controllers/spree/user_sessions_controller.rb
+++ b/app/controllers/spree/user_sessions_controller.rb
@@ -1,0 +1,30 @@
+module Spree
+  class UserSessionsController < ::Devise::SessionsController
+    helper_method :title
+    helper_method :stored_location
+    layout 'spree/storefront'
+
+    include Spree::Core::ControllerHelpers::Order
+    include Spree::LocaleUrls
+    include Spree::ThemeConcern
+    include Spree::IntegrationsHelper if defined?(Spree::IntegrationsHelper)
+
+    helper 'spree/wishlist'
+    helper 'spree/currency'
+    helper 'spree/locale'
+    helper 'spree/storefront_locale'
+    helper 'spree/integrations' if defined?(Spree::IntegrationsHelper)
+
+    protected
+
+    def translation_scope
+      'devise.user_sessions'
+    end
+
+    private
+
+    def title
+      Spree.t(:login)
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = Rails.application.credentials.secret_key_base
+  config.secret_key = Rails.application.credentials.secret_key_base || ENV.fetch('SECRET_KEY_BASE')
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
@@ -24,13 +24,13 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch('MAIL_FROM_ADDRESS', "support@#{Spree.root_domain}")
+  config.mailer_sender = ENV.fetch('MAIL_FROM_ADDRESS', "support@mystore.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Spree::DeviseMailer'
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'Spree::BaseMailer'
+  config.parent_mailer = 'Spree::BaseMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = Rails.application.credentials.secret_key_base || ENV.fetch('SECRET_KEY_BASE')
+  config.secret_key = Rails.application.credentials.secret_key_base || ENV['SECRET_KEY_BASE']
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,25 @@ Rails.application.routes.draw do
   # We ask that you don't use the :as option here, as Spree relies on it being
   # the default of "spree".
   mount Spree::Core::Engine, at: '/'
-  devise_for :users, class_name: "Spree::User"
+
+  # Fix Devise for Storefront to utilize translations
+  Spree::Core::Engine.routes.draw do
+    # Storefront routes
+    scope '(:locale)', locale: /#{Spree.available_locales.join('|')}/, defaults: { locale: nil } do
+      # Authentication with Devise
+      devise_for(
+        Spree.user_class.model_name.singular_route_key,
+        class_name: Spree.user_class.to_s,
+        path: :user,
+        controllers: {
+          sessions: 'spree/user_sessions',
+          passwords: 'spree/user_passwords',
+          registrations: 'spree/user_registrations'
+        },
+        router_name: :spree
+      )
+    end
+  end
 
   mount Sidekiq::Web => "/sidekiq" # access it at http://localhost:3000/sidekiq
 


### PR DESCRIPTION
To work in tandem with https://github.com/spree/spree/pull/12700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced custom controllers for user sessions, registrations, and password resets with improved localization and theming for the storefront.
- **Configuration**
  - Updated authentication and mailer settings for enhanced flexibility and clearer defaults.
- **Routing**
  - Revised authentication routes to support localized URLs and custom controller handling within the storefront.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->