### PR TITLE
Add `spree_google_analytics`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,8 @@ gem "spree_emails", spree_opts
 gem "spree_sample", spree_opts
 gem "spree_admin", spree_opts
 gem "spree_storefront", spree_opts
-gem "spree_stripe", '~> 1.2.0'
+gem "spree_stripe", '~> 1.2'
+gem "spree_google_analytics", "~> 1.0"
 gem "spree_i18n"
 
 # Sentry for error/performance monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,6 +683,11 @@ GEM
     spree_extension (0.1.0)
       activerecord (>= 4.2)
       spree_core
+    spree_google_analytics (1.0.0)
+      spree (>= 5.1.0.beta)
+      spree_admin (>= 5.1.0.beta)
+      spree_extension
+      spree_storefront (>= 5.1.0.beta)
     spree_i18n (5.3.1)
       i18n_data
       kaminari-i18n
@@ -855,10 +860,11 @@ DEPENDENCIES
   spree (~> 5.1.0.beta)
   spree_admin (~> 5.1.0.beta)
   spree_emails (~> 5.1.0.beta)
+  spree_google_analytics (~> 1.0)
   spree_i18n
   spree_sample (~> 5.1.0.beta)
   spree_storefront (~> 5.1.0.beta)
-  spree_stripe (~> 1.2.0)
+  spree_stripe (~> 1.2)
   stimulus-rails
   timecop
   turbo-rails

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This starter uses:
 
 * **[Spree Commerce 5](https://spreecommerce.org/announcing-spree-5-the-biggest-open-source-release-ever/)**, the biggest release ever, which includes Admin Dashboard, API and Storefront - everything you need to start developing your new eCommerce application/store/marketeplace
 * Stripe for payment processing, thanks to the official [Spree Stripe gem](https://github.com/spree/spree_stripe)
+* Google Analytics 4 integration, thanks to the official [Spree Google Analytics gem](https://github.com/spree/spree_google_analytics)
 * [Devise](https://github.com/heartcombo/devise) for authentication
 * [Sidekiq](https://github.com/mperham/sidekiq) for background jobs
 * PostgreSQL as a database


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added integration with Google Analytics 4.

- **Documentation**
  - Updated documentation to mention Google Analytics 4 integration and reference the official Spree Google Analytics gem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->