### PR TITLE
Fallback to memory store cache if redis cache is not set

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,8 @@ Rails.application.configure do
       write_timeout:      0.2, # Defaults to 1 second
       reconnect_attempts: 2,   # Defaults to 1
     }
+  else
+    config.cache_store = :memory_store
   end
 
   # Replace the default in-process and non-durable queuing backend for Active Job.


### PR DESCRIPTION
better than no caching at all!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache reliability in the production environment by automatically falling back to an in-memory cache if Redis is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->