### PR TITLE
Fix: drop selenium-webdriver dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ group :development, :test do
   gem 'rubocop', '~> 1.23'
   gem 'rubocop-performance'
   gem 'rubocop-rails'
-  gem 'selenium-webdriver', '~> 4.10.0'
 
   # monitoring
   gem 'pry'


### PR DESCRIPTION
This is handled by spree_dev_tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the selenium-webdriver dependency from development and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->