### PR TITLE
WIP: Fix local Spree sub-gems not loading from SPREE_PATH

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ if spree_path
     gem 'spree_admin'
     gem 'spree_core'
     gem 'spree_api'
-    gem 'spree_emails'
   end
 else
   spree_version = '>= 5.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,13 @@ end
 spree_path = ENV['SPREE_PATH']
 
 if spree_path
-  gem 'spree', path: "#{spree_path}/spree"
-  gem 'spree_admin', path: "#{spree_path}/spree/admin"
+  path "#{spree_path}/spree" do
+    gem 'spree'
+    gem 'spree_admin'
+    gem 'spree_core'
+    gem 'spree_api'
+    gem 'spree_emails'
+  end
 else
   spree_version = '>= 5.4.0'
   gem 'spree', spree_version


### PR DESCRIPTION
When SPREE_PATH is set, the Gemfile used individual path references for
`spree` and `spree_admin` but their sub-dependencies (`spree_core`,
`spree_api`, `spree_emails`) were still resolved from RubyGems.

This caused both the installed gem and local monorepo code to load
simultaneously, producing a boot warning:
  warning: already initialized constant Spree::VERSION

More critically, edits to local spree/core or spree/api files had no
effect at runtime since the installed gem took precedence.

Fix: replace individual `gem ..., path:` calls with a `path` block and
explicitly list all sub-gems so Bundler resolves the full dependency
tree from the local checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved local development dependency management by consolidating Spree component loading into a shared local-path configuration for local builds.
  * Ensures additional core and API components are included when using the local Spree path, while remote/packaged dependency behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->