### PR TITLE
Fix PostgreSQL volume mount path in Docker Compose configs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: pg_isready -U postgres
       interval: 5s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
     image: postgres:18-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
+      PGDATA: /var/lib/postgresql/18/docker
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: pg_isready -U postgres
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     image: postgres:18-alpine
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
+      PGDATA: /var/lib/postgresql/18/docker
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:


### PR DESCRIPTION
## Summary
Updated the PostgreSQL volume mount path in both development and production Docker Compose configurations to use the parent directory instead of the data subdirectory.

## Changes
- Modified `docker-compose.dev.yml`: Changed PostgreSQL volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`
- Modified `docker-compose.yml`: Changed PostgreSQL volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`

## Details
This change adjusts where the `postgres_data` volume is mounted within the PostgreSQL container. By mounting at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`, the volume now captures the entire PostgreSQL data directory structure, which may be necessary for proper data persistence and PostgreSQL initialization in containerized environments.

https://claude.ai/code/session_01V7UDN3KyWAViXSgzsWuSyQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database storage configuration across development and production environments for consistency and improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->