### PR TITLE
Action Mailer should use the same basic SMTP settings as production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ PORT=3000
 # SMTP_USERNAME=
 # SMTP_PASSWORD=
 # SMTP_FROM_ADDRESS=store@example.com
+# Production only: used as the host for URLs generated in emails.
 # RAILS_HOST=example.com
 
 # File Storage — auto-detected from credentials, falls back to local disk

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,9 +5,19 @@ Rails.application.configure do
   # Otherwise use Letter Opener to preview emails in the browser.
   if ENV["SMTP_HOST"].present?
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = { address: ENV["SMTP_HOST"], port: ENV.fetch("SMTP_PORT", 1025).to_i }
+    config.action_mailer.smtp_settings = {
+      address:              ENV["SMTP_HOST"],
+      port:                 ENV.fetch("SMTP_PORT", 1025).to_i,
+      user_name:            ENV["SMTP_USERNAME"],
+      password:             ENV["SMTP_PASSWORD"],
+      authentication:       :plain,
+      enable_starttls_auto: true
+    }
+    config.action_mailer.default_options = { from: ENV["SMTP_FROM_ADDRESS"] } if ENV["SMTP_FROM_ADDRESS"].present?
+    config.action_mailer.raise_delivery_errors = true
   else
     config.action_mailer.delivery_method = :letter_opener
+    config.action_mailer.raise_delivery_errors = false
   end
   config.action_mailer.perform_deliveries = true
 
@@ -42,9 +52,6 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
-
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
 
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development now supports configurable SMTP email server settings via environment variables and a conditional default "From" address.

* **Changes**
  * Development falls back to local email preview when SMTP isn't configured.
  * Email delivery error reporting in development is now enabled only when using an external SMTP server.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spree/spree-starter/pull/1343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->