### PR TITLE
Drop the unused web service healthcheck from dev compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -96,12 +96,6 @@ services:
     command: ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
     ports:
       - "${SPREE_PORT:-3000}:3000"
-    healthcheck:
-      test: curl -f http://localhost:3000/up || exit 1
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
 
   worker:
     <<: *app


### PR DESCRIPTION
## Summary

The web service's `curl /up` healthcheck in `docker-compose.dev.yml` ran every 10 seconds, generating ~6 noisy log lines per minute in dev:

```
web-1  | Started GET "/up" for 127.0.0.1 at 2026-06-09 15:45:22 +0000
web-1  | Processing by Rails::HealthController#show as */*
web-1  |   Rendering html template
web-1  |   Rendered html template (Duration: 0.0ms | GC: 0.0ms)
web-1  | Completed 200 OK in 1ms (Views: 0.5ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.0ms)
```

It served no purpose in dev:

- Nothing in `docker-compose.dev.yml` references it via `depends_on: condition: service_healthy`. Only `web` and `worker` use that block, and they wait on the data services (postgres / redis / meilisearch), not on web itself.
- `@spree/cli`'s `spree dev` doesn't run `docker compose up --wait`.
- `spree init` polls `/up` over HTTP directly (`packages/cli/src/commands/init.ts:81`), which is an app-level readiness check independent of the container healthcheck.

The data services' healthchecks (postgres / redis / meilisearch) stay — those are load-bearing for `web`/`worker` startup ordering.

Production `docker-compose.yml` keeps its web healthcheck for orchestrator integration (Heroku / K8s / ECS readiness probes); this PR touches only `docker-compose.dev.yml`.

## Test plan

- [x] Confirmed no `depends_on` block in `docker-compose.dev.yml` references the web service via `service_healthy`
- [x] Confirmed no @spree/cli command relies on the container healthcheck (only `spree init` checks readiness, and it does so via HTTP against `/up` from the host)
- [ ] After merge: tail logs in a fresh `spree dev` session, confirm no more `Rails::HealthController#show` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed health check configuration from the development environment to streamline container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->