### PR TITLE
remove `listen` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ group :development, :test do
   gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'
   gem 'dotenv-rails'
   gem 'letter_opener'
-  gem 'listen'
   gem 'rubocop-rails-omakase', require: false
   gem 'simplecov-cobertura'
   gem 'spree_dev_tools'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,10 +357,6 @@ GEM
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
-    listen (3.10.0)
-      logger
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     local_time (3.0.3)
     logger (1.7.0)
     lograge (0.14.0)
@@ -549,9 +545,6 @@ GEM
       activerecord (>= 7.2)
       activesupport (>= 7.2)
       i18n
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     rbs (4.0.3)
       logger
       prism (>= 1.6.0)
@@ -888,7 +881,6 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   letter_opener
-  listen
   lograge
   meilisearch (>= 0.28)
   pg (~> 1.1)
@@ -1046,7 +1038,6 @@ CHECKSUMS
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
-  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   local_time (3.0.3) sha256=c69a8974d993fdf6e60db02977ed23c070f203dcb3a1ff0de52ad3d2393f8303
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   lograge (0.14.0) sha256=42371a75823775f166f727639f5ddce73dd149452a55fc94b90c303213dc9ae1
@@ -1130,8 +1121,6 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   ransack (4.4.1) sha256=6aeaac36fc19088570e10da1044e6cfd88c740e20f871b84566fd30e32b7a63d
-  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
-  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,8 +21,6 @@ Rails.application.configure do
   end
   config.action_mailer.perform_deliveries = true
 
-  # Improved file watching
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Make code changes take effect immediately without server restart.


### PR DESCRIPTION
config/environments/development.rb set config.file_watcher = ActiveSupport::EventedFileUpdateChecker (with the listen gem). Evented watching uses Linux inotify inside the container, and inotify events don't cross a Docker bind mount from a macOS host — the container never learns a host-side file was created or edited. So new files (like your template override) stayed invisible until a restart forced a fresh boot-time scan. This is a verified, well-known Docker-on-Mac issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development setup by removing a file-watching dependency and reverting to the default watcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->