### PR TITLE
Bind Postgres and Meilisearch to loopback for dev security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ PORT=3000
 # RAILS_MAX_THREADS=3
 # WEB_CONCURRENCY=1
 
+# Docker host ports — override when another project already holds the default.
+# Postgres and Meilisearch bind to 127.0.0.1. SPREE_DB_PORT applies to
+# docker-compose.dev.yml only (the quick-start compose doesn't publish Postgres).
+# SPREE_PORT=3000
+# SPREE_DB_PORT=5433
+# SPREE_MEILISEARCH_PORT=7700
+
 # SSL (defaults to true in production — set to false for local dev or non-SSL proxies)
 # RAILS_FORCE_SSL=false
 # RAILS_ASSUME_SSL=false

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The app is now running at [http://localhost:3000](http://localhost:3000):
 - **Store API:** [http://localhost:3000/api/v3/store/products](http://localhost:3000/api/v3/store/products)
 - **Sidekiq:** [http://localhost:3000/sidekiq](http://localhost:3000/sidekiq)
 - **Health:** [http://localhost:3000/up](http://localhost:3000/up)
-- **PostgreSQL (host):** `localhost:5433` (user: `postgres`, db: `spree_development`) — connect with TablePlus, DataGrip, or `psql`
+- **PostgreSQL (host):** `localhost:5433` (user: `postgres`, db: `spree_development`) — connect with TablePlus, DataGrip, or `psql`. Bound to `127.0.0.1` only; override the port with `SPREE_DB_PORT` when running several projects side by side.
 
 ### How development works
 
@@ -82,8 +82,11 @@ If this is verbose, install the [`@spree/cli`](https://www.npmjs.com/package/@sp
 |---|---|---|
 | `SECRET_KEY_BASE` | Yes | Generate any 64-byte hex string. Stable across restarts so cookies/sessions survive. |
 | `SPREE_PORT` | No | Host port for the web service (default `3000`) |
-| `SPREE_DB_PORT` | No | Host port for Postgres (default `5433`) |
+| `SPREE_DB_PORT` | No | Host port for Postgres (default `5433`, bound to `127.0.0.1`) |
+| `SPREE_MEILISEARCH_PORT` | No | Host port for Meilisearch (default `7700`, bound to `127.0.0.1`) |
 | `SIDEKIQ_DB_POOL` | No | Worker thread pool size (default `27`) |
+
+Postgres and Meilisearch run passwordless in dev, so their host ports bind to loopback only — set the `SPREE_*_PORT` variables to run multiple projects side by side instead of exposing them beyond `localhost`.
 
 For production deployments (S3, SMTP, Sentry, etc.) see [the environment variables docs](https://docs.spreecommerce.org/developer/deployment/environment_variables).
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,7 +63,10 @@ services:
     ports:
       # Forwarded for native DB clients (TablePlus, DataGrip, psql on host).
       # Default 5433 avoids collision with a host-native Postgres on 5432.
-      - "${SPREE_DB_PORT:-5433}:5432"
+      # Bound to loopback: this postgres runs passwordless (trust auth), and a
+      # 0.0.0.0 publish bypasses host firewalls on Linux (Docker inserts its
+      # NAT rules ahead of ufw/firewalld), exposing it to the local network.
+      - "127.0.0.1:${SPREE_DB_PORT:-5433}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
     healthcheck:
@@ -87,7 +90,9 @@ services:
     volumes:
       - meilisearch_data:/meili_data
     ports:
-      - "7700:7700"
+      # Forwarded for the Meilisearch dashboard / host debugging. Loopback for
+      # the same reason as postgres: no API key is set in dev.
+      - "127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}:7700"
     healthcheck:
       test: curl -f http://localhost:7700/health || exit 1
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,10 @@ services:
     volumes:
       - meilisearch_data:/meili_data
     ports:
-      - "7700:7700"
+      # Loopback-only: the app reaches Meilisearch over the compose network;
+      # the host port is for debugging and must not be LAN-reachable (Docker's
+      # NAT rules bypass host firewalls on Linux, and no API key is set).
+      - "127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}:7700"
     healthcheck:
       test: curl -f http://localhost:7700/health || exit 1
       interval: 5s


### PR DESCRIPTION
## Summary

Restricts Postgres and Meilisearch host ports to `127.0.0.1` in development to prevent unintended network exposure. Both services run passwordless in dev, so binding to `0.0.0.0` would expose them to the local network on Linux (Docker's NAT rules bypass host firewalls).

## Changes

- **docker-compose.dev.yml**: Bind Postgres port to `127.0.0.1:${SPREE_DB_PORT:-5433}` and Meilisearch to `127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}` with explanatory comments
- **docker-compose.yml**: Bind Meilisearch port to `127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}` (production compose) with security rationale
- **.env.example**: Document the new `SPREE_MEILISEARCH_PORT` variable and explain loopback binding strategy
- **README.md**: Update Postgres connection docs and add environment variables table entry for `SPREE_MEILISEARCH_PORT`; clarify that port overrides enable running multiple projects side by side

## Implementation Details

- Both services remain accessible from the Rails app via the compose network (internal DNS)
- Host debugging/client connections (TablePlus, DataGrip, psql) still work via `localhost:PORT`
- Users can override ports with `SPREE_DB_PORT` and `SPREE_MEILISEARCH_PORT` env vars to run multiple projects simultaneously
- No functional changes to the app itself—purely a security hardening of the dev environment

https://claude.ai/code/session_01KhFxgBpt1G7kaiCPkZqiiT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified development setup notes for local service ports and loopback-only access.
  * Added guidance for overriding host ports when running multiple projects side by side.

* **Bug Fixes**
  * Limited database and search service ports to `localhost` in development and compose setups.
  * Reduced the risk of exposing local services beyond the machine while keeping them available for debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->