### PR TITLE
For docker environments use mailpit for email catching

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,19 @@ If this is verbose, install the [`@spree/cli`](https://www.npmjs.com/package/@sp
 | `SPREE_PORT` | No | Host port for the web service (default `3000`) |
 | `SPREE_DB_PORT` | No | Host port for Postgres (default `5433`, bound to `127.0.0.1`) |
 | `SPREE_MEILISEARCH_PORT` | No | Host port for Meilisearch (default `7700`, bound to `127.0.0.1`) |
+| `MAILPIT_UI_PORT` | No | Host port for the Mailpit web UI (default `8025`, bound to `127.0.0.1`) |
+| `MAILPIT_SMTP_PORT` | No | Host port for Mailpit's SMTP endpoint (default `1025`, bound to `127.0.0.1`) |
 | `SIDEKIQ_DB_POOL` | No | Worker thread pool size (default `27`) |
 
 Postgres and Meilisearch run passwordless in dev, so their host ports bind to loopback only — set the `SPREE_*_PORT` variables to run multiple projects side by side instead of exposing them beyond `localhost`.
 
 For production deployments (S3, SMTP, Sentry, etc.) see [the environment variables docs](https://docs.spreecommerce.org/developer/deployment/environment_variables).
+
+### Emails in development
+
+All outgoing mail is captured by [Mailpit](https://mailpit.axllent.org/) — nothing is ever delivered externally. Open **http://localhost:8025** to read every email the app sends (order confirmations, password resets, invitations, …). No configuration needed; it works out of the box with both compose files.
+
+To deliver through a real SMTP provider instead, set `SMTP_HOST` (and `SMTP_USERNAME`/`SMTP_PASSWORD`/`SMTP_PORT`) in `.env` — those take precedence over the Mailpit default.
 
 ## Customization
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,14 +5,20 @@ Rails.application.configure do
   # Otherwise use Letter Opener to preview emails in the browser.
   if ENV["SMTP_HOST"].present?
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = {
+    smtp_settings = {
       address:              ENV["SMTP_HOST"],
       port:                 ENV.fetch("SMTP_PORT", 1025).to_i,
-      user_name:            ENV["SMTP_USERNAME"],
-      password:             ENV["SMTP_PASSWORD"],
-      authentication:       :plain,
       enable_starttls_auto: true
     }
+    # Only request SMTP-AUTH when credentials are provided. Local mail catchers
+    # (Mailpit, MailHog) accept anonymous delivery; requesting auth with a nil
+    # user raises "SMTP-AUTH requested but missing user name" before connecting.
+    if ENV["SMTP_USERNAME"].present?
+      smtp_settings[:user_name]      = ENV["SMTP_USERNAME"]
+      smtp_settings[:password]       = ENV["SMTP_PASSWORD"]
+      smtp_settings[:authentication] = :plain
+    end
+    config.action_mailer.smtp_settings = smtp_settings
     config.action_mailer.default_options = { from: ENV["SMTP_FROM_ADDRESS"] } if ENV["SMTP_FROM_ADDRESS"].present?
     config.action_mailer.raise_delivery_errors = true
   else

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,14 +66,19 @@ Rails.application.configure do
   # Works with any SMTP provider (Resend, Postmark, Mailgun, SendGrid, SES, etc.)
   if ENV["SMTP_HOST"].present?
     config.action_mailer.delivery_method = :smtp
-    config.action_mailer.smtp_settings = {
+    smtp_settings = {
       address:              ENV["SMTP_HOST"],
       port:                 ENV.fetch("SMTP_PORT", 587).to_i,
-      user_name:            ENV["SMTP_USERNAME"],
-      password:             ENV["SMTP_PASSWORD"],
-      authentication:       :plain,
       enable_starttls_auto: true
     }
+    # Only request SMTP-AUTH when credentials are provided — the quick-start
+    # compose delivers to Mailpit anonymously; real providers set SMTP_USERNAME.
+    if ENV["SMTP_USERNAME"].present?
+      smtp_settings[:user_name]      = ENV["SMTP_USERNAME"]
+      smtp_settings[:password]       = ENV["SMTP_PASSWORD"]
+      smtp_settings[:authentication] = :plain
+    end
+    config.action_mailer.smtp_settings = smtp_settings
   end
 
   config.action_mailer.default_url_options = { host: ENV.fetch("RAILS_HOST", "example.com") }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,8 @@ x-app: &app
       condition: service_healthy
     meilisearch:
       condition: service_healthy
+    mailpit:
+      condition: service_started
   env_file: .env
   environment: &app-env
     DATABASE_URL: postgres://postgres@postgres:5432/spree_development
@@ -33,6 +35,10 @@ x-app: &app
     RAILS_FORCE_SSL: "false"
     RAILS_ASSUME_SSL: "false"
     MEILISEARCH_URL: http://meilisearch:7700
+    # All outgoing mail is captured by Mailpit — read it at http://localhost:8025.
+    # Set SMTP_HOST (and friends) in .env to deliver through a real provider instead.
+    SMTP_HOST: ${SMTP_HOST:-mailpit}
+    SMTP_PORT: ${SMTP_PORT:-1025}
     # RAILS_ENV / BUNDLE_* are baked into the dev image (Dockerfile dev stage).
     BOOTSNAP_CACHE_DIR: /rails/tmp/cache/bootsnap
   volumes:
@@ -98,6 +104,20 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      # Loopback-only, matching meilisearch: reachable from the host browser
+      # but not the LAN (Docker's NAT rules bypass host firewalls on Linux).
+      # 8025 = web UI — open http://localhost:8025 to read captured mail.
+      # 1025 = SMTP endpoint the app delivers to (in-cluster as mailpit:1025).
+      - "127.0.0.1:${MAILPIT_UI_PORT:-8025}:8025"
+      - "127.0.0.1:${MAILPIT_SMTP_PORT:-1025}:1025"
+    environment:
+      MP_MAX_MESSAGES: "500"
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
 
   web:
     <<: *app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ x-app: &app
       condition: service_healthy
     meilisearch:
       condition: service_healthy
+    mailpit:
+      condition: service_started
   env_file: .env
   environment: &app-env
     DATABASE_URL: postgres://postgres@postgres:5432/spree_production
@@ -18,6 +20,10 @@ x-app: &app
     RAILS_FORCE_SSL: "false"
     RAILS_ASSUME_SSL: "false"
     MEILISEARCH_URL: http://meilisearch:7700
+    # All outgoing mail is captured by Mailpit — read it at http://localhost:8025.
+    # Set SMTP_HOST (and friends) in .env to deliver through a real provider instead.
+    SMTP_HOST: ${SMTP_HOST:-mailpit}
+    SMTP_PORT: ${SMTP_PORT:-1025}
 
 services:
   postgres:
@@ -57,6 +63,20 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      # Loopback-only, matching meilisearch: reachable from the host browser
+      # but not the LAN (Docker's NAT rules bypass host firewalls on Linux).
+      # 8025 = web UI — open http://localhost:8025 to read captured mail.
+      # 1025 = SMTP endpoint the app delivers to (in-cluster as mailpit:1025).
+      - "127.0.0.1:${MAILPIT_UI_PORT:-8025}:8025"
+      - "127.0.0.1:${MAILPIT_SMTP_PORT:-1025}:1025"
+    environment:
+      MP_MAX_MESSAGES: "500"
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
 
   web:
     <<: *app


### PR DESCRIPTION
letter_opener as fallback for native envs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local email capture support for development, including a web inbox to view outgoing messages.
  - Updated default email settings so development environments send mail to the local capture service automatically.

- **Bug Fixes**
  - Improved mail delivery configuration so authentication is only used when needed, avoiding errors with local SMTP catchers.

- **Documentation**
  - Expanded setup docs with email environment variables and instructions for viewing captured emails or switching to a real SMTP provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->