### PR TITLE
Fix running tests in docker environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # Required
 SECRET_KEY_BASE=change-me-generate-with-bin-rails-secret
-DATABASE_URL=postgres://postgres@localhost:5432/spree_production
 REDIS_URL=redis://localhost:6379/0
+
+# Database — both compose files configure this themselves (the quick-start
+# compose sets DATABASE_URL; docker-compose.dev.yml sets DATABASE_HOST so dev
+# and test each resolve their own database). Only set DATABASE_URL for
+# non-Docker production-style runs: in .env it overrides database.yml inside
+# the dev container and points every Rails env at one database.
+# DATABASE_URL=postgres://postgres@localhost:5432/spree_production
 # REDIS_CACHE_URL=redis://localhost:6380/0  # dedicated cache Redis (falls back to REDIS_URL)
 
 # Web Server

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If this is verbose, install the [`@spree/cli`](https://www.npmjs.com/package/@sp
 
 ### Environment variables
 
-`docker-compose.dev.yml` sets sensible dev defaults for `DATABASE_URL`, `REDIS_URL`, and `MEILISEARCH_URL`, while `RAILS_ENV` is baked into the Dockerfile `dev` stage. Most of `.env.example` is production-shaped and ignored in dev. The only variable you must set is:
+`docker-compose.dev.yml` sets sensible dev defaults for `DATABASE_HOST`, `REDIS_URL`, and `MEILISEARCH_URL`, while `RAILS_ENV` is baked into the Dockerfile `dev` stage. (It deliberately avoids `DATABASE_URL`, which would override `database.yml` for every Rails env and point the test suite at the development database.) Most of `.env.example` is production-shaped and ignored in dev. The only variable you must set is:
 
 | Variable | Required | Notes |
 |---|---|---|

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,13 @@ x-app: &app
       condition: service_started
   env_file: .env
   environment: &app-env
-    DATABASE_URL: postgres://postgres@postgres:5432/spree_development
+    # database.yml builds dev/test configs from DATABASE_HOST/DATABASE_USERNAME
+    # (port 5432 is its default). Deliberately NOT DATABASE_URL: a URL overrides
+    # database.yml for every Rails env, so in-container rspec would hit the dev
+    # DB and trip DatabaseCleaner's remote-URL safeguard. Both are pinned here
+    # so native-dev values in .env (env_file above) can't leak into the container.
+    DATABASE_HOST: postgres
+    DATABASE_USERNAME: postgres
     REDIS_URL: redis://redis:6379/0
     SECRET_KEY_BASE: ${SECRET_KEY_BASE}
     RAILS_FORCE_SSL: "false"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+# Force (not ||=) because the dev container bakes RAILS_ENV=development;
+# without this, in-container rspec boots the dev env and DatabaseCleaner
+# truncates the development database.
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
Force test env, drop using `DATABASE_URL` (breaks with database cleaner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment configuration so local, Docker, and test runs use the intended database settings consistently.
  * Prevented the test suite from accidentally picking up a non-test Rails environment.
  * Clarified setup guidance to avoid overriding environment-specific database configuration.
* **Documentation**
  * Updated environment-variable instructions to reflect the preferred database settings for development and container-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->