### PR TITLE
Document running tests in Docker and the spree rspec command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,8 +150,12 @@ bin/rails db:seed      # Seed the databases
 
 ## Testing
 
+Native (host Ruby):
+
 ```bash
 bundle exec rspec                           # Full test suite
 bundle exec rspec spec/models/              # Model specs only
 bundle exec rspec spec/models/my_model.rb   # Single file
 ```
+
+Docker (via `@spree/cli`): `spree rspec …` runs the same commands inside the web container with `RAILS_ENV=test`, against the `spree_test` database. First run: `spree rails db:test:prepare`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ dc down
 
 If this is verbose, install the [`@spree/cli`](https://www.npmjs.com/package/@spree/cli) which wraps these as `spree exec`, `spree rails`, `spree generate`, `spree migrate`, etc.
 
+### Running tests
+
+Tests run inside the web container against a dedicated `spree_test` database — your development data is never touched. Create the test database once, then run RSpec:
+
+```bash
+dc exec web bin/rails db:test:prepare        # one-time test database setup
+dc exec -e RAILS_ENV=test web bundle exec rspec
+dc exec -e RAILS_ENV=test web bundle exec rspec spec/models/my_model_spec.rb:15
+```
+
+With the [`@spree/cli`](https://www.npmjs.com/package/@spree/cli) this is `spree rails db:test:prepare` and `spree rspec` (which sets `RAILS_ENV=test` for you):
+
+```bash
+spree rspec                                  # full suite
+spree rspec spec/models/my_model_spec.rb:15  # one example
+spree rspec --format documentation
+```
+
 ### Environment variables
 
 `docker-compose.dev.yml` sets sensible dev defaults for `DATABASE_HOST`, `REDIS_URL`, and `MEILISEARCH_URL`, while `RAILS_ENV` is baked into the Dockerfile `dev` stage. (It deliberately avoids `DATABASE_URL`, which would override `database.yml` for every Rails env and point the test suite at the development database.) Most of `.env.example` is production-shaped and ignored in dev. The only variable you must set is:


### PR DESCRIPTION
Now that the dev compose resolves the test database from `database.yml` (rather than a `DATABASE_URL` that overrode every Rails env), in-container test runs no longer need workarounds. This documents that flow.

## Changes

- **README.md** — adds a "Running tests" section under Development, showing both the raw `docker compose exec` form (with `-e RAILS_ENV=test`) and the `@spree/cli` shorthand (`spree rails db:test:prepare` + `spree rspec`).
- **CLAUDE.md** — points the Testing section at `spree rspec` / `spree rails db:test:prepare` for the Docker path, alongside the existing native Ruby commands.

The `spree rspec` command referenced here ships in `@spree/cli` 2.3.8 (spree/spree#14285, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSLtt2FfUL5ZuAL6Mf9kbq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application, configuration, or test code modifications.
> 
> **Overview**
> Documents how to run RSpec in the Docker dev setup now that tests can use `database.yml`’s `spree_test` database instead of being forced onto dev via `DATABASE_URL`.
> 
> **README** adds a **Running tests** section with one-time `db:test:prepare`, raw `docker compose exec` commands using `RAILS_ENV=test`, and `@spree/cli` shortcuts (`spree rspec`, `spree rails db:test:prepare`).
> 
> **CLAUDE.md** splits **Testing** into native host Ruby vs Docker/`@spree/cli` paths with the same `spree rspec` guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c3ae286eff792803ff20cb48bf0516c4f74f17a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded testing guidance in the project docs.
  * Clarified how to run specs in both a native Ruby setup and via Docker.
  * Added commands for preparing the test database and running the full suite or a single spec example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->