### PR TITLE
Add spree_dashboard gem for spree monorepo development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,10 @@ spree_path = ENV.fetch('SPREE_PATH', nil)
 if spree_path
   path "#{spree_path}/spree" do
     gem 'spree'
-    gem 'spree_admin'
     gem 'spree_core'
     gem 'spree_api'
+    gem 'spree_admin'
+    gem 'spree_dashboard'
     gem 'spree_emails'
   end
 else


### PR DESCRIPTION
Added 'spree_dashboard' gems to the Gemfile for local development of spree monorepo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change for local monorepo development; production bundles without SPREE_PATH are unaffected.
> 
> **Overview**
> When **`SPREE_PATH`** points at the Spree monorepo, the Gemfile now loads **`spree_dashboard`** from the local path alongside the other Spree gems.
> 
> The path-group gem order is adjusted so **`spree_admin`** sits after **`spree_api`**, with **`spree_dashboard`** listed immediately after **`spree_admin`**. The published-gem **`else`** branch is unchanged and still does not declare **`spree_dashboard`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d92eb0f5a3efe2c9c1c582811b73ceeb7004ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard functionality to the application’s available commerce components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->