### PR TITLE
Bake the React Dashboard into the image, served at /dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,48 @@
 # check=error=true
 
 ARG RUBY_VERSION=4.0.1
+ARG NODE_VERSION=22
+# Which React Dashboard the image bakes (served by Rails at /dashboard —
+# the single-node topology: same origin as the Admin API, so no CORS or
+# cookie configuration). Only dist/ reaches the final image; the Node
+# toolchain never does.
+#
+#   stock  (default) — the template published inside @spree/cli, with
+#                      dependency pins matching that CLI release
+#   custom           — your own dashboard app, provided as a named build
+#                      context (`spree build --production` does this):
+#
+#     docker build backend/ \
+#       --build-arg DASHBOARD_SOURCE=custom \
+#       --build-context dashboard-src=./apps/dashboard
+ARG DASHBOARD_SOURCE=stock
+
+FROM docker.io/library/node:$NODE_VERSION-slim AS dashboard-stock
+
+WORKDIR /dashboard
+RUN npm pack @spree/cli --pack-destination /tmp && \
+  tar -xzf /tmp/spree-cli-*.tgz -C /tmp && \
+  cp -r /tmp/package/dist/templates/dashboard-starter/. . && \
+  corepack enable pnpm && \
+  pnpm install && \
+  VITE_BASE_PATH=/dashboard/ pnpm build
+
+FROM docker.io/library/node:$NODE_VERSION-slim AS dashboard-custom
+
+WORKDIR /dashboard
+COPY --from=dashboard-src . .
+# Defensive: host node_modules/build output must never leak into the image
+# build (wrong platform, stale artifacts).
+RUN rm -rf node_modules dist .tanstack && \
+  corepack enable pnpm && \
+  pnpm install && \
+  VITE_BASE_PATH=/dashboard/ pnpm build
+
+# BuildKit resolves stages lazily: with the default `stock`, the custom
+# stage (and its dashboard-src context) is never evaluated, so plain
+# `docker build backend/` needs no extra flags.
+FROM dashboard-${DASHBOARD_SOURCE} AS dashboard
+
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
 WORKDIR /rails
@@ -74,6 +116,11 @@ USER 1000:1000
 # Copy built artifacts: gems, application
 COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --chown=rails:rails --from=build /rails /rails
+
+# Stock React Dashboard, served by Rails at /dashboard (see the dashboard
+# stage above). The bundle is origin-relative — it works on any host.
+COPY --chown=rails:rails --from=dashboard /dashboard/dist /rails/dashboard
+ENV SPREE_DASHBOARD_DIST_PATH="/rails/dashboard"
 
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,17 @@ ARG NODE_VERSION=22
 #       --build-arg DASHBOARD_SOURCE=custom \
 #       --build-context dashboard-src=./apps/dashboard
 ARG DASHBOARD_SOURCE=stock
+# CLI release line the stock template is extracted from. Caret-pinned so
+# template fixes in CLI minors/patches reach image rebuilds automatically
+# while a future CLI major (which may reshape the template layout) requires
+# a deliberate bump here.
+ARG SPREE_CLI_VERSION=^2.4.0
 
 FROM docker.io/library/node:$NODE_VERSION-slim AS dashboard-stock
+ARG SPREE_CLI_VERSION
 
 WORKDIR /dashboard
-RUN npm pack @spree/cli --pack-destination /tmp && \
+RUN npm pack "@spree/cli@${SPREE_CLI_VERSION}" --pack-destination /tmp && \
   tar -xzf /tmp/spree-cli-*.tgz -C /tmp && \
   cp -r /tmp/package/dist/templates/dashboard-starter/. . && \
   corepack enable pnpm && \

--- a/Gemfile
+++ b/Gemfile
@@ -34,10 +34,13 @@ if spree_path
     gem 'spree_emails'
   end
 else
-  spree_version = '>= 5.5.0.rc3'
+  spree_version = '>= 5.6.0.rc1'
   gem 'spree', spree_version
   gem 'spree_admin', spree_version
   gem 'spree_emails', spree_version
+  # Serves the React Dashboard at /dashboard (see the Dockerfile's dashboard
+  # stage — SPREE_DASHBOARD_DIST_PATH points at the baked build).
+  gem 'spree_dashboard', spree_version
 end
 
 # Extensions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -665,10 +665,10 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    spree (5.5.3)
-      spree_api (= 5.5.3)
-      spree_core (= 5.5.3)
-    spree_admin (5.5.3)
+    spree (5.6.0.rc1)
+      spree_api (= 5.6.0.rc1)
+      spree_core (= 5.6.0.rc1)
+    spree_admin (5.6.0.rc1)
       active_link_to
       breadcrumbs_on_rails (~> 4.1)
       chartkick (~> 5.0)
@@ -679,7 +679,7 @@ GEM
       local_time (~> 3.0)
       mapkick-rb (~> 0.1)
       ruby-oembed (~> 0.18)
-      spree (>= 5.5.3)
+      spree (>= 5.6.0.rc1)
       stimulus-rails
       tailwindcss-rails (>= 4.0)
       tailwindcss-ruby (>= 4.0)
@@ -689,12 +689,12 @@ GEM
       adyen-ruby-api-library (>= 10.3, < 12.0)
       spree (>= 5.3.0)
       spree_admin (>= 5.3.0)
-    spree_api (5.5.3)
+    spree_api (5.6.0.rc1)
       alba (~> 3.0)
       oj (~> 3.16)
-      spree_core (= 5.5.3)
+      spree_core (= 5.6.0.rc1)
       typelizer (~> 0.11.0)
-    spree_core (5.5.3)
+    spree_core (5.6.0.rc1)
       active_storage_validations (>= 1.3, < 4)
       acts-as-taggable-on
       acts_as_list (>= 0.8)
@@ -733,6 +733,8 @@ GEM
       tracking_number
       validates_zipcode
       wannabe_bool
+    spree_dashboard (5.6.0.rc1)
+      spree (>= 5.6.0.rc1)
     spree_dev_tools (0.6.1)
       awesome_print
       brakeman
@@ -760,8 +762,8 @@ GEM
       spree (>= 5.4.0.alpha)
       timecop
       webdrivers
-    spree_emails (5.5.3)
-      spree (>= 5.5.3)
+    spree_emails (5.6.0.rc1)
+      spree (>= 5.6.0.rc1)
     spree_extension (1.0.2)
       thor (~> 1.0)
     spree_i18n (5.3.2)
@@ -897,11 +899,12 @@ DEPENDENCIES
   sentry-sidekiq
   sidekiq
   simplecov-cobertura
-  spree (>= 5.5.0.rc3)
-  spree_admin (>= 5.5.0.rc3)
+  spree (>= 5.6.0.rc1)
+  spree_admin (>= 5.6.0.rc1)
   spree_adyen
+  spree_dashboard (>= 5.6.0.rc1)
   spree_dev_tools
-  spree_emails (>= 5.5.0.rc3)
+  spree_emails (>= 5.6.0.rc1)
   spree_i18n
   spree_paypal_checkout
   spree_stripe
@@ -1164,13 +1167,14 @@ CHECKSUMS
   simplecov-cobertura (3.2.0) sha256=70d702658677fcb20e5aceb6915ccf8bc62ff2ccd38b62b3ad5c9db5c0888740
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
-  spree (5.5.3) sha256=2f8fe7306f5e0f00dd594296a17864835db38df09425056d747c0762425b8bf0
-  spree_admin (5.5.3) sha256=cc61efb8d259e01f27b8021fd46f775c490dc4e497228d06c7ecee748381ad9a
+  spree (5.6.0.rc1) sha256=c905cc2702b8ee84c3bdc45667fbf1ba241e333bd48693ac799be3785347fb2c
+  spree_admin (5.6.0.rc1) sha256=4200ffdfc75adb0d2ba70a884ebb3ffa207a7946f38f0f8e3471ffdf991f5a79
   spree_adyen (0.11.0) sha256=f22941571d4cde4ae12fc7aa13f37d85005b71f2c9c2ff50ec8d1dceabfd564a
-  spree_api (5.5.3) sha256=0a005bbfadd9dce2a1f5d85dba052fe7139a7cc1ff44463a572bcc071720f33d
-  spree_core (5.5.3) sha256=4bf6540d00886674ebdc7ccbb97aadde2871d3f4be5fe756576006c2eccaec87
+  spree_api (5.6.0.rc1) sha256=40df9315fef412be820e21621a9f6287191326b9fe71be2622f887b9482a3d35
+  spree_core (5.6.0.rc1) sha256=7b835bbf36f79d94a834d029425c5655cc3348e804e5ece837748bb006812dc4
+  spree_dashboard (5.6.0.rc1) sha256=f531c03356865dd485adc912563d63bc2c23c0c96d38501edb0cf881445efb24
   spree_dev_tools (0.6.1) sha256=4d86ab6643cbc7a2b813faa70cd397028380ee8cd2be923f6eb5db8cc126ea14
-  spree_emails (5.5.3) sha256=eade869094a6408884105577a9dc4455603102c1a7cdb3db8b8bddf840d8e387
+  spree_emails (5.6.0.rc1) sha256=46f2876d1f0850289cda71be08f0c99415f767f21d2d5a8a8c5104ee29d0c8a0
   spree_extension (1.0.2) sha256=71725dafe45319a2be1bd2b564a416afe8029af8e18ac703bdb835e09553e1df
   spree_i18n (5.3.2) sha256=03b805235ca156644951f6bc3d07cbe43d0aa01134c4a27e3f3304011956f79b
   spree_paypal_checkout (0.7.1) sha256=89a5715a3b23b2ac04a27ddfd12416101fab03996cf70826d35dedef3bb4b9de

--- a/db/migrate/20260715145102_add_store_id_to_spree_role_users.spree.rb
+++ b/db/migrate/20260715145102_add_store_id_to_spree_role_users.spree.rb
@@ -1,0 +1,11 @@
+# This migration comes from spree (originally 20260613000001)
+class AddStoreIdToSpreeRoleUsers < ActiveRecord::Migration[7.2]
+  def change
+    # Denormalizes the store a role assignment applies within, so role
+    # resolution (Spree::Ability) can scope by store without depending on the
+    # polymorphic resource. Kept null: true here; existing rows are backfilled
+    # by `spree:role_users:backfill_store_ids` and presence is enforced
+    # on the model.
+    add_reference :spree_role_users, :store, null: true
+  end
+end

--- a/db/migrate/20260715145103_add_store_id_to_spree_taxons.spree.rb
+++ b/db/migrate/20260715145103_add_store_id_to_spree_taxons.spree.rb
@@ -1,0 +1,12 @@
+# This migration comes from spree (originally 20260626000001)
+class AddStoreIdToSpreeTaxons < ActiveRecord::Migration[7.2]
+  # NOTE: After running this migration, existing taxons have +store_id IS NULL+
+  # and keep resolving their store through their taxonomy (Taxon.for_store falls
+  # back to the taxonomy join). Run the backfill to populate +store_id+ directly,
+  # which is what taxonomy-less categories (Spree::Category) rely on:
+  #
+  #   bundle exec rake spree:taxons:backfill_store_id
+  def change
+    add_reference :spree_taxons, :store, null: true, if_not_exists: true
+  end
+end

--- a/db/migrate/20260715145104_add_products_count_to_spree_taxons.spree.rb
+++ b/db/migrate/20260715145104_add_products_count_to_spree_taxons.spree.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree (originally 20260627000001)
+class AddProductsCountToSpreeTaxons < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_taxons, :products_count, :integer, default: 0, null: false, if_not_exists: true
+    add_index :spree_taxons, :products_count, if_not_exists: true
+  end
+end

--- a/db/migrate/20260715145105_add_store_id_to_spree_promotions.spree.rb
+++ b/db/migrate/20260715145105_add_store_id_to_spree_promotions.spree.rb
@@ -1,0 +1,11 @@
+# This migration comes from spree (originally 20260628000001)
+class AddStoreIdToSpreePromotions < ActiveRecord::Migration[7.2]
+  # NOTE: After running this migration, existing promotions have +store_id IS NULL+
+  # and are invisible to +Promotion.for_store+. Run the backfill immediately to
+  # copy ownership from the legacy +spree_promotions_stores+ join table:
+  #
+  #   bundle exec rake spree:upgrade:populate_single_store_associations
+  def change
+    add_reference :spree_promotions, :store, null: true, if_not_exists: true
+  end
+end

--- a/db/migrate/20260715145106_add_store_id_to_spree_payment_methods.spree.rb
+++ b/db/migrate/20260715145106_add_store_id_to_spree_payment_methods.spree.rb
@@ -1,0 +1,12 @@
+# This migration comes from spree (originally 20260628000002)
+class AddStoreIdToSpreePaymentMethods < ActiveRecord::Migration[7.2]
+  # NOTE: After running this migration, existing payment methods have
+  # +store_id IS NULL+ and are invisible to +PaymentMethod.for_store+. Run the
+  # backfill immediately to copy ownership from the legacy
+  # +spree_payment_methods_stores+ join table:
+  #
+  #   bundle exec rake spree:upgrade:populate_single_store_associations
+  def change
+    add_reference :spree_payment_methods, :store, null: true, if_not_exists: true
+  end
+end

--- a/db/migrate/20260715145107_add_preorder_fields_to_spree_variants.spree.rb
+++ b/db/migrate/20260715145107_add_preorder_fields_to_spree_variants.spree.rb
@@ -1,0 +1,8 @@
+# This migration comes from spree (originally 20260630000001)
+class AddPreorderFieldsToSpreeVariants < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_variants, :preorderable, :boolean
+    add_column :spree_variants, :preorder_ships_at, :datetime
+    add_column :spree_variants, :backorder_limit, :integer
+  end
+end

--- a/db/migrate/20260715145108_add_fingerprint_to_spree_credit_cards.spree.rb
+++ b/db/migrate/20260715145108_add_fingerprint_to_spree_credit_cards.spree.rb
@@ -1,0 +1,40 @@
+# This migration comes from spree (originally 20260707000001)
+class AddFingerprintToSpreeCreditCards < ActiveRecord::Migration[7.2]
+  INDEX_NAME = 'index_spree_credit_cards_unique_fingerprint'.freeze
+
+  def up
+    add_column :spree_credit_cards, :fingerprint, :string
+
+    # Prevent duplicate saved cards (same gateway fingerprint + expiry) per user
+    # and payment method at the database level, backing the application-level
+    # check against concurrent writes. Only active, fingerprinted cards are
+    # constrained, so legacy/non-gateway cards (NULL fingerprint) and
+    # soft-deleted rows are left untouched.
+    if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+      # MySQL has no partial indexes, but treats NULL as distinct in unique
+      # indexes, so NULL fingerprints are naturally allowed. COALESCE on
+      # deleted_at keeps soft-deleted rows from colliding with active ones.
+      execute <<-SQL
+        CREATE UNIQUE INDEX #{INDEX_NAME}
+        ON spree_credit_cards(
+          user_id,
+          payment_method_id,
+          fingerprint,
+          month,
+          year,
+          (COALESCE(deleted_at, CAST('1970-01-01' AS DATETIME)))
+        )
+      SQL
+    else
+      add_index :spree_credit_cards, [:user_id, :payment_method_id, :fingerprint, :month, :year],
+                unique: true,
+                where: 'fingerprint IS NOT NULL AND deleted_at IS NULL',
+                name: INDEX_NAME
+    end
+  end
+
+  def down
+    remove_index :spree_credit_cards, name: INDEX_NAME
+    remove_column :spree_credit_cards, :fingerprint
+  end
+end

--- a/db/migrate/20260715145109_add_import_id_status_index_to_spree_import_rows.spree.rb
+++ b/db/migrate/20260715145109_add_import_id_status_index_to_spree_import_rows.spree.rb
@@ -1,0 +1,8 @@
+# This migration comes from spree (originally 20260710000001)
+class AddImportIdStatusIndexToSpreeImportRows < ActiveRecord::Migration[7.2]
+  def change
+    # Powers the Admin API's per-poll grouped status counts and the
+    # failed-rows listing without a full scan on large imports.
+    add_index :spree_import_rows, [:import_id, :status]
+  end
+end

--- a/db/migrate/20260715145110_add_preferences_to_spree_exports.spree.rb
+++ b/db/migrate/20260715145110_add_preferences_to_spree_exports.spree.rb
@@ -1,0 +1,8 @@
+# This migration comes from spree (originally 20260711000001)
+class AddPreferencesToSpreeExports < ActiveRecord::Migration[7.2]
+  def change
+    # Same serialized preferences store spree_imports already has — first
+    # consumer is the `results_url` the export-done email links back to.
+    add_column :spree_exports, :preferences, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_15_145110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -319,6 +319,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.datetime "created_at", null: false
     t.boolean "default", default: false, null: false
     t.datetime "deleted_at", precision: nil
+    t.string "fingerprint"
     t.bigint "gateway_customer_id"
     t.string "gateway_customer_profile_id"
     t.string "gateway_payment_profile_id"
@@ -335,6 +336,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.index ["deleted_at"], name: "index_spree_credit_cards_on_deleted_at"
     t.index ["gateway_customer_id"], name: "index_spree_credit_cards_on_gateway_customer_id"
     t.index ["payment_method_id"], name: "index_spree_credit_cards_on_payment_method_id"
+    t.index ["user_id", "payment_method_id", "fingerprint", "month", "year"], name: "index_spree_credit_cards_unique_fingerprint", unique: true, where: "((fingerprint IS NOT NULL) AND (deleted_at IS NULL))"
     t.index ["user_id"], name: "index_spree_credit_cards_on_user_id"
   end
 
@@ -422,6 +424,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.datetime "created_at", null: false
     t.integer "format", null: false
     t.string "number", limit: 32, null: false
+    t.text "preferences"
     t.jsonb "search_params"
     t.bigint "store_id", null: false
     t.string "type", null: false
@@ -520,6 +523,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.datetime "updated_at", null: false
     t.text "validation_errors"
     t.index ["import_id", "row_number"], name: "index_spree_import_rows_on_import_id_and_row_number", unique: true
+    t.index ["import_id", "status"], name: "index_spree_import_rows_on_import_id_and_status"
     t.index ["import_id"], name: "index_spree_import_rows_on_import_id"
     t.index ["item_type", "item_id"], name: "index_spree_import_rows_on_item"
     t.index ["status"], name: "index_spree_import_rows_on_status"
@@ -933,9 +937,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.jsonb "private_metadata"
     t.jsonb "public_metadata"
     t.jsonb "settings"
+    t.bigint "store_id"
     t.string "type"
     t.datetime "updated_at", null: false
     t.index ["id", "type"], name: "index_spree_payment_methods_on_id_and_type"
+    t.index ["store_id"], name: "index_spree_payment_methods_on_store_id"
   end
 
   create_table "spree_payment_methods_stores", id: false, force: :cascade do |t|
@@ -1339,6 +1345,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.bigint "promotion_category_id"
     t.jsonb "public_metadata"
     t.datetime "starts_at", precision: nil
+    t.bigint "store_id"
     t.string "type"
     t.datetime "updated_at", null: false
     t.integer "usage_limit"
@@ -1350,6 +1357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.index ["path"], name: "index_spree_promotions_on_path"
     t.index ["promotion_category_id"], name: "index_spree_promotions_on_promotion_category_id"
     t.index ["starts_at"], name: "index_spree_promotions_on_starts_at"
+    t.index ["store_id"], name: "index_spree_promotions_on_store_id"
   end
 
   create_table "spree_promotions_stores", force: :cascade do |t|
@@ -1527,6 +1535,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.bigint "resource_id"
     t.string "resource_type"
     t.bigint "role_id"
+    t.bigint "store_id"
     t.datetime "updated_at", precision: nil
     t.bigint "user_id"
     t.string "user_type", null: false
@@ -1534,6 +1543,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.index ["resource_id", "resource_type", "user_id", "user_type", "role_id"], name: "idx_on_resource_id_resource_type_user_id_user_type__5600304ec6", unique: true
     t.index ["resource_type", "resource_id"], name: "index_spree_role_users_on_resource"
     t.index ["role_id"], name: "index_spree_role_users_on_role_id"
+    t.index ["store_id"], name: "index_spree_role_users_on_store_id"
     t.index ["user_id"], name: "index_spree_role_users_on_user_id"
     t.index ["user_type"], name: "index_spree_role_users_on_user_type"
   end
@@ -2029,10 +2039,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.integer "position", default: 0
     t.string "pretty_name"
     t.jsonb "private_metadata"
+    t.integer "products_count", default: 0, null: false
     t.jsonb "public_metadata"
     t.bigint "rgt"
     t.string "rules_match_policy", default: "all", null: false
     t.string "sort_order", default: "manual", null: false
+    t.bigint "store_id"
     t.bigint "taxonomy_id"
     t.datetime "updated_at", null: false
     t.index ["children_count"], name: "index_spree_taxons_on_children_count"
@@ -2045,7 +2057,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.index ["permalink"], name: "index_taxons_on_permalink"
     t.index ["position"], name: "index_spree_taxons_on_position"
     t.index ["pretty_name"], name: "index_spree_taxons_on_pretty_name"
+    t.index ["products_count"], name: "index_spree_taxons_on_products_count"
     t.index ["rgt"], name: "index_spree_taxons_on_rgt"
+    t.index ["store_id"], name: "index_spree_taxons_on_store_id"
     t.index ["taxonomy_id"], name: "index_taxons_on_taxonomy_id"
   end
 
@@ -2120,6 +2134,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
   end
 
   create_table "spree_variants", force: :cascade do |t|
+    t.integer "backorder_limit"
     t.string "barcode"
     t.string "cost_currency"
     t.decimal "cost_price", precision: 10, scale: 2
@@ -2132,6 +2147,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_142512) do
     t.boolean "is_master", default: false
     t.integer "media_count", default: 0, null: false
     t.integer "position"
+    t.datetime "preorder_ships_at"
+    t.boolean "preorderable"
     t.bigint "primary_media_id"
     t.jsonb "private_metadata"
     t.bigint "product_id"


### PR DESCRIPTION
Ships the single-node topology in the official image:

- **Dockerfile**: a throw-away Node stage builds the stock React Dashboard — `DASHBOARD_SOURCE=stock` (default) extracts the template bundled in the published `@spree/cli`; `custom` builds a `dashboard-src` build context (what `spree build --production` passes for customized dashboards). Only `dist/` reaches the final image; Rails serves it at `/dashboard` via `SPREE_DASHBOARD_DIST_PATH`.
- **Gemfile**: `spree_dashboard` in the versioned block + `spree_version = '>= 5.6.0.rc1'`; `Gemfile.lock` regenerated against the released RC1 gems.

> [!IMPORTANT]
> **Merge gate:** requires `@spree/cli@2.4.0` on npm (the Dockerfile's stock stage `npm pack`s the CLI for the embedded template — 2.3.9 doesn't carry it). That publishes automatically when spree/spree#14306 merges. Gems 5.6.0.rc1 are already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DzwNXZwhBsLqcJzwZwAmD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps Spree to 5.6 RC and adds migrations that require post-deploy backfills for store scoping; payment fingerprint uniqueness can affect saved-card writes. Docker stock builds depend on `@spree/cli@^2.4.0` being published.
> 
> **Overview**
> Ships the **single-node** topology: the production image builds a React admin dashboard during Docker build and Rails serves it at `/dashboard` on the same origin as the API.
> 
> The **Dockerfile** adds throw-away Node stages (`dashboard-stock` from `@spree/cli` template, or `dashboard-custom` via `dashboard-src` context), copies only `dist/` into the final image, and sets `SPREE_DASHBOARD_DIST_PATH`. Default `DASHBOARD_SOURCE=stock` needs no extra build flags.
> 
> **Dependencies** move to Spree `>= 5.6.0.rc1`, add **`spree_dashboard`** for gem installs, and refresh **`Gemfile.lock`**.
> 
> The **5.6 schema** adds nine Spree migrations: `store_id` on role users, taxons, promotions, and payment methods (with documented backfill rakes); taxon `products_count`; variant preorder fields; credit-card **fingerprint** with a partial unique index; import-row `(import_id, status)` index; and export **preferences**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f743186a628e0e3a0a542da34be755e30ddf953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ability to choose between the standard and a custom React Dashboard at container build time, and ships the selected build with the app.
  - Added preorder-related fields for variants (preorderable, preorder ships date, backorder limit).
- **Updates**
  - Raised the minimum supported Spree version for path-based installations to 5.6.0 release candidate 1.
  - Added the Spree Dashboard gem support for path-based installations.
- **Database Changes**
  - Added store scoping columns and indexes across multiple Spree tables.
  - Added fingerprinting with a uniqueness rule for saved credit cards.
  - Added export preferences, taxon product counting, and import status indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->