### PR TITLE
Support dedicated CDN_HOST and RAILS_HOST envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,14 +26,21 @@ PORT=3000
 # RAILS_FORCE_SSL=false
 # RAILS_ASSUME_SSL=false
 
+# Public host (production) — used for all generated URLs: image/attachment URLs
+# in API responses, links in emails. Host only, optionally with a port
+# (e.g. store.example.com or 203.0.113.7:8080). URLs use https unless both
+# RAILS_FORCE_SSL and RAILS_ASSUME_SSL are false.
+# RAILS_HOST=store.example.com
+
+# Optional CDN host for serving assets and images (host only, no protocol)
+# CDN_HOST=cdn.example.com
+
 # Email (SMTP) — set SMTP_HOST to enable email delivery, otherwise emails are logged
 # SMTP_HOST=smtp.sendgrid.net
 # SMTP_PORT=587
 # SMTP_USERNAME=
 # SMTP_PASSWORD=
 # SMTP_FROM_ADDRESS=store@example.com
-# Production only: used as the host for URLs generated in emails.
-# RAILS_HOST=example.com
 
 # File Storage — auto-detected from credentials, falls back to local disk
 # AWS_ACCESS_KEY_ID=

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,6 +33,22 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = ENV["RAILS_FORCE_SSL"] != "false"
 
+  # Canonical public host for all generated URLs — Active Storage attachment
+  # URLs in API payloads, links in emails, and any URL built outside a request
+  # context. Without it, URLs fall back to the store's URL setting (which is
+  # "localhost" on a fresh install). Host only, optionally with a port
+  # (e.g. "store.example.com" or "203.0.113.7:8080"). On Render the
+  # platform-provided external hostname is used unless RAILS_HOST is set.
+  public_host = ENV["RAILS_HOST"].presence || ENV["RENDER_EXTERNAL_HOSTNAME"].presence
+  if public_host
+    no_ssl = ENV["RAILS_ASSUME_SSL"] == "false" && ENV["RAILS_FORCE_SSL"] == "false"
+    routes.default_url_options = { host: public_host, protocol: no_ssl ? "http" : "https" }
+  end
+
+  # Serve compiled assets (and, via Spree.cdn_host in config/initializers/spree.rb,
+  # Active Storage attachments) from a CDN. Host only, no protocol.
+  config.asset_host = ENV["CDN_HOST"] if ENV["CDN_HOST"].present?
+
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
@@ -81,7 +97,7 @@ Rails.application.configure do
     config.action_mailer.smtp_settings = smtp_settings
   end
 
-  config.action_mailer.default_url_options = { host: ENV.fetch("RAILS_HOST", "example.com") }
+  config.action_mailer.default_url_options = { host: public_host || "example.com" }
   config.action_mailer.default_options = { from: ENV["SMTP_FROM_ADDRESS"] } if ENV["SMTP_FROM_ADDRESS"].present?
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -62,6 +62,11 @@ end
 Spree.user_class = 'Spree::User'
 Spree.admin_user_class = 'Spree::AdminUser'
 
+# Serve Active Storage attachment URLs (product images, logos, etc.) from a CDN
+# host instead of the application host. Host only, no protocol — the scheme
+# comes from routes.default_url_options (see config/environments/production.rb).
+Spree.cdn_host = ENV['CDN_HOST'] if ENV['CDN_HOST'].present?
+
 # Background job queue configuration
 Spree.queues.default = :default
 Spree.queues.events = :spree_events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,11 @@ x-app: &app
     DATABASE_URL: postgres://postgres@postgres:5432/spree_production
     REDIS_URL: redis://redis:6379/0
     SECRET_KEY_BASE: ${SECRET_KEY_BASE}
-    RAILS_FORCE_SSL: "false"
-    RAILS_ASSUME_SSL: "false"
+    RAILS_FORCE_SSL: ${RAILS_FORCE_SSL:-false}
+    RAILS_ASSUME_SSL: ${RAILS_ASSUME_SSL:-false}
+    # Public host for generated URLs (image/attachment URLs in API responses,
+    # email links). Override in .env when serving from a real domain or IP.
+    RAILS_HOST: ${RAILS_HOST:-localhost:${SPREE_PORT:-3000}}
     MEILISEARCH_URL: http://meilisearch:7700
     # All outgoing mail is captured by Mailpit — read it at http://localhost:8025.
     # Set SMTP_HOST (and friends) in .env to deliver through a real provider instead.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how all generated URLs behave in production (API images, emails, assets); misconfigured hosts can break links or mixed-content, but scope is configuration-only with sensible fallbacks.
> 
> **Overview**
> Adds **`RAILS_HOST`** and **`CDN_HOST`** so production and Docker quick-start can set the canonical app host and an optional CDN without relying on the store URL default (`localhost`).
> 
> In **production**, `RAILS_HOST` (or `RENDER_EXTERNAL_HOSTNAME` on Render) drives `routes.default_url_options` (http vs https when both SSL env flags are `false`) and **Action Mailer** link hosts. **`CDN_HOST`** sets `config.asset_host` and **`Spree.cdn_host`** for Active Storage attachment URLs in API payloads.
> 
> **`.env.example`** documents both variables; **`docker-compose.yml`** defaults `RAILS_HOST` to `localhost:${SPREE_PORT:-3000}` and wires SSL flags from `.env` with `false` defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0611ad835a9bbe9359f6313da49c728dae7db74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable public host settings for generated links, image URLs, attachments, and email URLs.
  * Added optional CDN host support for serving product images and other attachments.
  * Added configurable HTTP/HTTPS behavior for generated URLs.

* **Documentation**
  * Clarified public host, CDN, and SSL configuration in environment and Docker Compose examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->