### PR TITLE
Slim down the Docker image size 747MB → 580MB (−167MB, −22%),

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,11 @@ FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
 WORKDIR /rails
 
-# Install base packages
+# Install base packages. No postgresql-client: the pg gem vendors its own
+# libpq, and Debian's postgresql-client drags in ~70MB of perl/gnupg
+# dependencies. The dev stage adds it back for psql convenience.
 RUN apt-get update -qq && \
-  apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+  apt-get install --no-install-recommends -y curl libjemalloc2 libvips && \
   ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
   rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
@@ -110,6 +112,11 @@ ENV RAILS_ENV="development" \
   BUNDLE_DEPLOYMENT="0" \
   BUNDLE_WITHOUT=""
 
+# psql for debugging against the compose postgres (production doesn't need it).
+RUN apt-get update -qq && \
+  apt-get install --no-install-recommends -y postgresql-client && \
+  rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
 # Install dev/test gems on top of the production bundle from the build stage.
 RUN bundle install && \
   rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
@@ -132,8 +139,11 @@ RUN groupadd --system --gid 1000 rails && \
   useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash
 USER 1000:1000
 
-# Copy built artifacts: gems, application
-COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
+# Copy built artifacts: gems, application. tailwindcss-ruby's exe/ (the
+# ~105MB standalone Tailwind CLI) is excluded — it's only used by
+# assets:precompile in the build stage; the gem's Ruby files stay so
+# Bundler.require keeps working at boot.
+COPY --chown=rails:rails --from=build --exclude=ruby/*/gems/tailwindcss-ruby-*/exe "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --chown=rails:rails --from=build /rails /rails
 
 # React Dashboard, served by Rails at /dashboard (see the dashboard stage


### PR DESCRIPTION
1. Dropped postgresql-client from the base stage — the pg gem vendors its own libpq, and this package was silently dragging in the full Perl stack plus gnupg (~58MB in the apt layer, now 178→120MB). Added it back in the dev stage only, so bin/rails dbconsole and psql still work in the dev container.
2. Excluded tailwindcss-ruby's exe/ from the final image via COPY --exclude — the 105MB standalone Tailwind CLI is only used by assets:precompile in the build stage (bundle layer now 282→173MB). I probed first that --exclude works with the stable docker/dockerfile:1 frontend, so this builds the same on Render/Railway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes with dev parity preserved; main caveat is production must not invoke the Tailwind CLI at runtime (already confined to the build stage).
> 
> **Overview**
> Shrinks the **production** Docker image (~747MB → ~580MB) by keeping build-only tooling out of the final stage.
> 
> **`postgresql-client`** is removed from the shared **`base`** stage (production no longer ships `psql` or Debian’s Perl/gnupg stack). Database connectivity still relies on the **`pg`** gem’s bundled **libpq**. **`postgresql-client`** is installed only in the **`dev`** target so compose/debug workflows keep **`psql`** / **`dbconsole`**.
> 
> The production **`COPY`** of **`BUNDLE_PATH`** from **`build`** now uses **`COPY --exclude`** to omit **`tailwindcss-ruby`**’s **`exe/`** (~105MB Tailwind CLI). Precompile still runs in **`build`**; the gem’s Ruby files remain so **Bundler** boot is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a4f51a35bbb8da62891e3a2d2d01a31004cc7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the production image footprint by excluding the standalone Tailwind CLI binary from runtime artifacts.
  * Kept PostgreSQL client tools available in development environments without including them in the shared base image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->