### PR TITLE
Make Meilisearch fully optional — database search provider by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,9 @@ PORT=3000
 # MISSION_CONTROL_PASSWORD=
 
 # Docker host ports — override when another project already holds the default.
-# Postgres and Meilisearch bind to 127.0.0.1. SPREE_DB_PORT applies to
-# docker-compose.dev.yml only (the quick-start compose doesn't publish Postgres).
+# Postgres binds to 127.0.0.1. SPREE_DB_PORT applies to docker-compose.dev.yml
+# only (the quick-start compose doesn't publish Postgres). SPREE_MEILISEARCH_PORT
+# applies only when the optional meilisearch compose service is enabled.
 # SPREE_PORT=3000
 # SPREE_DB_PORT=5433
 # SPREE_MEILISEARCH_PORT=7700
@@ -75,7 +76,10 @@ PORT=3000
 # RAILS_ENV=production
 # RAILS_LOG_LEVEL=info
 
-# Search
+# Search — product search runs on the database by default. To switch to
+# Meilisearch, set MEILISEARCH_URL (uncomment the meilisearch blocks in the
+# compose file when using Docker, or point at your own instance) and reindex
+# with `bin/rails spree:search:reindex`.
 # MEILISEARCH_URL=
 # MEILISEARCH_API_KEY=
 

--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,6 @@
 brew 'ruby' # see .ruby-version for required version
 brew 'postgresql@18'
 brew 'redis'
-brew 'meilisearch'
+# brew 'meilisearch' # optional search provider — set MEILISEARCH_URL to enable
 brew 'vips'
 brew 'overmind'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Otherwise, refer to:
 - Store API v3 at `/api/v3/store/`
 - Admin API v3 at `/api/v3/admin/`
 - Background jobs via Solid Queue (in Postgres, runs inside Puma by default) — dashboard at `/jobs`
-- Search via Meilisearch (when `MEILISEARCH_URL` is set)
+- Product search runs on the database by default; optional Meilisearch provider activates when `MEILISEARCH_URL` is set (compose service ships commented out)
 
 ## Key Files
 

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,8 @@ gem 'tailwindcss-rails'
 gem 'thruster', require: false
 gem 'turbo-rails'
 
-# Search
+# Search — client for the optional Meilisearch provider; product search runs
+# on the database unless MEILISEARCH_URL is set
 gem 'meilisearch', '>= 0.28'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,8 +21,9 @@ x-app: &app
   depends_on:
     postgres:
       condition: service_healthy
-    meilisearch:
-      condition: service_healthy
+    # Uncomment when enabling the optional meilisearch service below.
+    # meilisearch:
+    #   condition: service_healthy
     mailpit:
       condition: service_started
   env_file: .env
@@ -40,7 +41,10 @@ x-app: &app
     # Dev runs more job threads than the production default of 3 — imports and
     # image processing finish fast, and there's no checkout traffic to protect.
     JOB_THREADS: ${JOB_THREADS:-10}
-    MEILISEARCH_URL: http://meilisearch:7700
+    # Product search runs on the database by default. To switch to Meilisearch,
+    # uncomment this together with the meilisearch depends_on/service/volume
+    # blocks, then reindex: spree rake spree:search:reindex
+    # MEILISEARCH_URL: http://meilisearch:7700
     # All outgoing mail is captured by Mailpit — read it at http://localhost:8025.
     # Set SMTP_HOST (and friends) in .env to deliver through a real provider instead.
     SMTP_HOST: ${SMTP_HOST:-mailpit}
@@ -87,19 +91,22 @@ services:
       timeout: 5s
       retries: 5
 
-  meilisearch:
-    image: getmeili/meilisearch:latest
-    volumes:
-      - meilisearch_data:/meili_data
-    ports:
-      # Forwarded for the Meilisearch dashboard / host debugging. Loopback for
-      # the same reason as postgres: no API key is set in dev.
-      - "127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}:7700"
-    healthcheck:
-      test: curl -f http://localhost:7700/health || exit 1
-      interval: 5s
-      timeout: 5s
-      retries: 5
+  # Optional Meilisearch search provider (typo tolerance, instant facets).
+  # Uncomment together with the meilisearch lines under x-app's depends_on and
+  # environment, and the meilisearch_data volume at the bottom.
+  # meilisearch:
+  #   image: getmeili/meilisearch:latest
+  #   volumes:
+  #     - meilisearch_data:/meili_data
+  #   ports:
+  #     # Forwarded for the Meilisearch dashboard / host debugging. Loopback for
+  #     # the same reason as postgres: no API key is set in dev.
+  #     - "127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}:7700"
+  #   healthcheck:
+  #     test: curl -f http://localhost:7700/health || exit 1
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 5
 
   mailpit:
     image: axllent/mailpit:latest
@@ -129,7 +136,7 @@ services:
 
 volumes:
   postgres_data:
-  meilisearch_data:
+  # meilisearch_data:
   storage_data:
   bundle_cache:
   tmp_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ x-app: &app
   depends_on:
     postgres:
       condition: service_healthy
-    meilisearch:
-      condition: service_healthy
+    # Uncomment when enabling the optional meilisearch service below.
+    # meilisearch:
+    #   condition: service_healthy
     mailpit:
       condition: service_started
   env_file: .env
@@ -19,7 +20,10 @@ x-app: &app
     # Public host for generated URLs (image/attachment URLs in API responses,
     # email links). Override in .env when serving from a real domain or IP.
     RAILS_HOST: ${RAILS_HOST:-localhost:${SPREE_PORT:-3000}}
-    MEILISEARCH_URL: http://meilisearch:7700
+    # Product search runs on the database by default. To switch to Meilisearch,
+    # uncomment this together with the meilisearch depends_on/service/volume
+    # blocks, then reindex: docker compose exec web bin/rails spree:search:reindex
+    # MEILISEARCH_URL: http://meilisearch:7700
     # All outgoing mail is captured by Mailpit — read it at http://localhost:8025.
     # Set SMTP_HOST (and friends) in .env to deliver through a real provider instead.
     SMTP_HOST: ${SMTP_HOST:-mailpit}
@@ -39,20 +43,23 @@ services:
       timeout: 5s
       retries: 5
 
-  meilisearch:
-    image: getmeili/meilisearch:latest
-    volumes:
-      - meilisearch_data:/meili_data
-    ports:
-      # Loopback-only: the app reaches Meilisearch over the compose network;
-      # the host port is for debugging and must not be LAN-reachable (Docker's
-      # NAT rules bypass host firewalls on Linux, and no API key is set).
-      - "127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}:7700"
-    healthcheck:
-      test: curl -f http://localhost:7700/health || exit 1
-      interval: 5s
-      timeout: 5s
-      retries: 5
+  # Optional Meilisearch search provider (typo tolerance, instant facets).
+  # Uncomment together with the meilisearch lines under x-app's depends_on and
+  # environment, and the meilisearch_data volume at the bottom.
+  # meilisearch:
+  #   image: getmeili/meilisearch:latest
+  #   volumes:
+  #     - meilisearch_data:/meili_data
+  #   ports:
+  #     # Loopback-only: the app reaches Meilisearch over the compose network;
+  #     # the host port is for debugging and must not be LAN-reachable (Docker's
+  #     # NAT rules bypass host firewalls on Linux, and no API key is set).
+  #     - "127.0.0.1:${SPREE_MEILISEARCH_PORT:-7700}:7700"
+  #   healthcheck:
+  #     test: curl -f http://localhost:7700/health || exit 1
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 5
 
   mailpit:
     image: axllent/mailpit:latest
@@ -87,5 +94,5 @@ services:
 
 volumes:
   postgres_data:
-  meilisearch_data:
+  # meilisearch_data:
   storage_data:


### PR DESCRIPTION
## What

New installs no longer run a Meilisearch container or set `MEILISEARCH_URL` — Spree's Database search provider is the out-of-the-box default. Meilisearch becomes a documented, config-only opt-in.

- `docker-compose.yml` + `docker-compose.dev.yml` — the meilisearch service, its `depends_on` entries, the hardcoded `MEILISEARCH_URL`, and the `meilisearch_data` volume are commented out with instructions for re-enabling
- `.env.example` — documents the opt-in path (uncomment the compose blocks or point at your own instance, then `bin/rails spree:search:reindex`)
- `Brewfile` — `meilisearch` commented out
- `Gemfile` — the `meilisearch` gem **stays** (see below)
- `CLAUDE.md` — architecture note updated

## Why

The Database provider covers development and small catalogs fine, and the native (no-Docker) path never provisioned Meilisearch anyway — Docker installs were the odd one out. This drops an always-on container (image pull, RAM, volume) from the default stack, and since `SearchProvider::Database.indexing_required?` is false, the default stack also stops enqueueing `IndexJob`/`RemoveJob` on every product save.

Meilisearch remains the recommended production search provider — this changes what's provisioned by default, not the recommendation.

## Why the gem stays

The prebuilt `ghcr.io/spree/spree` image is built from this Gemfile. Existing quick-start installs have `MEILISEARCH_URL` + the meilisearch service in **their own** compose files (nothing rewrites them — `spree update` / `spree upgrade` / `spree eject` all leave compose alone), so when they pull a new `:latest` the gem must still be in the image or they'd hit a `LoadError` on first search. Keeping the gem means enabling Meilisearch never requires a custom image build.

## Compatibility

- **Existing Docker installs** (create-spree-app / starter-based): unaffected — their compose files are their own; Meilisearch stays active for them, including after `spree update` pulls a new image.
- **Production deploys with hosted Meilisearch**: unaffected — `MEILISEARCH_URL` is env-driven and the initializer is unchanged.
- **Native installs**: unaffected — they always opted in manually; `brew bundle` never uninstalls.
- ⚠️ **If you track this repo as an upstream and merge this change** while running Meilisearch: your search silently flips to the Database provider (no error). Re-enable by uncommenting the meilisearch blocks in your compose file and running `bin/rails spree:search:reindex`. The old container becomes an orphan (`docker compose down --remove-orphans` cleans it up); the index volume is preserved.

Both compose files validated in the default state and with all opt-in blocks uncommented (service, health-gated `depends_on`, env, volume all restore correctly).

Companion monorepo PR: spree/spree#14331 — updates create-spree-app tests and adds a `SPREE_MEILISEARCH=1` opt-in overlay for monorepo server development.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and compose defaults only; no runtime or search initializer changes. Teams that merge upstream compose while relying on Meilisearch must re-enable the commented blocks or search silently falls back to the database.
> 
> **Overview**
> **Default installs no longer start Meilisearch or set `MEILISEARCH_URL`** — product search is documented and configured to use Spree’s database provider until you opt in.
> 
> In **`docker-compose.yml`** and **`docker-compose.dev.yml`**, the Meilisearch service, health-gated `depends_on`, hardcoded `MEILISEARCH_URL`, and `meilisearch_data` volume are **commented out**, with inline steps to uncomment and run `spree:search:reindex`. **`.env.example`**, **`Brewfile`** (Homebrew `meilisearch` commented), **`Gemfile`** comments, and **`CLAUDE.md`** describe database search as default and Meilisearch as optional.
> 
> The **`meilisearch` gem remains** in the Gemfile so prebuilt images still support installs that already set `MEILISEARCH_URL` in their own compose files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb9169f5603cd0a5c1e5226eb9f8382d9336fef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product search now uses the database by default.
  * Meilisearch is available as an optional search provider when enabled.
  * Added guidance for configuring search ports and rebuilding the search index after switching providers.

* **Documentation**
  * Clarified database and search networking settings.
  * Updated setup documentation and dependency notes to reflect optional Meilisearch support.

* **Configuration**
  * Disabled Meilisearch by default in Docker Compose configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
