### PR TITLE
Support parallel dev environments (worktrees) on one machine

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,14 +9,14 @@ default: &default
 
 development:
   <<: *default
-  database: spree_development
+  database: <%= ENV.fetch("DATABASE_NAME") { "spree_development" } %>
   username: <%= ENV.fetch("DATABASE_USERNAME") { 'postgres' } %>
   host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
   port: <%= ENV.fetch("DATABASE_PORT") { 5432 }.to_i %>
 
 test:
   <<: *default
-  database: spree_test
+  database: <%= ENV.fetch("DATABASE_NAME_TEST") { "spree_test" } %>
   username: <%= ENV.fetch("DATABASE_USERNAME") { 'postgres' } %>
   host: <%= ENV.fetch("DATABASE_HOST") { "localhost" } %>
   port: <%= ENV.fetch("DATABASE_PORT") { 5432 }.to_i %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,11 @@ Rails.application.configure do
   end
   config.action_mailer.perform_deliveries = true
 
+  # Rails' default ".localhost" rule rejects Host headers that carry a port
+  # (foo.localhost:1355), which is how local https proxies (portless, Caddy)
+  # forward requests. Allow any .localhost host, with or without a port.
+  config.hosts << /\A[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?\z/i
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Make code changes take effect immediately without server restart.


### PR DESCRIPTION
## What

Two small development-only changes that let several checkouts of this app (e.g. git worktrees of the spree monorepo) run side by side on one machine:

- **`config/database.yml`**: the development and test database names can now be overridden via `DATABASE_NAME` / `DATABASE_NAME_TEST`. Defaults (`spree_development` / `spree_test`) are unchanged, matching the existing `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_USERNAME` pattern. This lets parallel environments share one Postgres with a database per branch.
- **`config/environments/development.rb`**: allow `.localhost` hosts whose Host header carries a port. Local https proxies (portless, Caddy) forward requests as `foo.localhost:<port>`, which Rails' default `.localhost` rule rejects with a blocked-host error.

## Why

The spree monorepo dev workflow now provisions one starter clone per git worktree, each with its own database copied from a seeded template and per-branch `.localhost` URLs behind a local proxy. Both changes are inert for the standard single-checkout setup — no env vars set, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Development and test configuration only; defaults unchanged when env vars are unset, with no production impact.
> 
> **Overview**
> Enables multiple local checkouts (e.g. git worktrees) to run on one machine without colliding on Postgres or blocked Host headers.
> 
> **`config/database.yml`** now lets development and test DB names be set with **`DATABASE_NAME`** and **`DATABASE_NAME_TEST`**, with the same defaults as before (`spree_development` / `spree_test`), aligned with the existing host/port/username env pattern.
> 
> **`config/environments/development.rb`** adds a **`config.hosts`** regex so `*.localhost` requests work when the Host header includes a port (typical for Caddy or similar local HTTPS proxies).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1d224d049106a7b0e97c26d50ae4e18af632a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->