### PR TITLE
Drop the claim_type column from spree_claims

### DIFF
--- a/db/migrate/20260804130055_remove_claim_type_from_spree_claims.spree.rb
+++ b/db/migrate/20260804130055_remove_claim_type_from_spree_claims.spree.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree (originally 20260807120001)
+class RemoveClaimTypeFromSpreeClaims < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :spree_claims, :claim_type, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_04_130054) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_130055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -549,7 +549,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_130054) do
   create_table "spree_claims", force: :cascade do |t|
     t.datetime "approved_at"
     t.datetime "canceled_at"
-    t.string "claim_type", null: false
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
     t.datetime "denied_at"


### PR DESCRIPTION
Mirrors spree/spree#14406, which removes `Claim#claim_type` in favour of the merchant-owned claim reason.

The starter carries a copy of the core migration that created the claims table, so it needs the matching follow-up migration. `schema.rb` was regenerated by running `db:migrate`, not hand-edited.

Merge after the core PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dropping a NOT NULL column is irreversible without a down migration and any code or integrations still reading `claim_type` will break until they use claim reasons; coordination with the core Spree PR is required.
> 
> **Overview**
> Adds a Spree engine migration that **drops** the required `claim_type` string column from `spree_claims`, matching upstream Spree’s move to classify claims via **`reason_id`** instead of a fixed type field.
> 
> `db/schema.rb` is updated to the new migration version so fresh `db:schema:load` installs claims without `claim_type`. Intended to land after the corresponding core Spree change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf5acd9c5e33440e4fc94ce1f34623402bce81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->