### PR TITLE
Add spree_easypost and allow tunnel hosts in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,11 +24,14 @@ gem 'propshaft'
 spree_path = ENV.fetch('SPREE_PATH', nil)
 
 if spree_path
-  path "#{spree_path}/spree" do
+  # Bundler's default path glob stops two levels deep; the extra level
+  # reaches provider gems under spree/providers/*.
+  path "#{spree_path}/spree", glob: '{,*,*/*,*/*/*}.gemspec' do
     gem 'spree'
     gem 'spree_core'
     gem 'spree_api'
     gem 'spree_dashboard'
+    gem 'spree_easypost'
     gem 'spree_emails'
   end
 else

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,6 +32,12 @@ Rails.application.configure do
   # forward requests. Allow any .localhost host, with or without a port.
   config.hosts << /\A[a-z0-9-]+(\.[a-z0-9-]+)*\.localhost(:\d+)?\z/i
 
+  # Tunnels that expose this dev server to the outside world, so third-party
+  # webhooks (carriers, payment gateways) can reach it. Each tunnel gets a
+  # fresh random hostname, so the whole domain is allowed rather than one name.
+  config.hosts << /\A[a-z0-9-]+\.trycloudflare\.com\z/i
+  config.hosts << /\A[a-z0-9-]+\.ngrok(-free)?\.(app|io|dev)\z/i
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Make code changes take effect immediately without server restart.


### PR DESCRIPTION
Two small changes that came out of testing the EasyPost delivery provider end to end against a local server.

**`spree_easypost` in the local-development block.** Provider gems live under `spree/providers/`, one level deeper than Bundler's default path glob reaches, so the glob is widened to find them. The gem is only listed in the `SPREE_PATH` branch, matching how the other monorepo gems are wired.

**Cloudflare and ngrok hostnames allowed in development.** A carrier or payment gateway can only deliver webhooks to a local server through a tunnel, and Rails rejects the tunnel's Host header by default. Each tunnel run gets a fresh random hostname, so the domain is allowed rather than a single host — and only in development.

## Not included

Installed migrations and `db/schema.rb`. Those are copies generated by `rails spree:install:migrations` from the Spree gems, whose sources already ship in the monorepo — committing the copies here would fork them, and the install task would later produce a second copy under a different timestamp.

`Gemfile.lock` is also left alone: a lock produced with `SPREE_PATH` set pins Spree to a local absolute path, which would not resolve for anyone else.